### PR TITLE
v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng-cli",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1461,9 +1461,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "lodash.get": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -328,11 +328,29 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+    },
     "buffer-from": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
-      "dev": true
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -529,6 +547,27 @@
         "which": "^1.2.9"
       }
     },
+    "csv-parser": {
+      "version": "1.12.1",
+      "resolved": "http://registry.npmjs.org/csv-parser/-/csv-parser-1.12.1.tgz",
+      "integrity": "sha512-r45M92nLnGP246ot0Yo5RvbiiMF5Bw/OTIdWJ3OQ4Vbv4hpOeoXVIPxdSmUw+fPJlQOseY+iigJyLSfPMIrddQ==",
+      "requires": {
+        "buffer-alloc": "^1.1.0",
+        "buffer-from": "^1.0.0",
+        "generate-function": "^1.0.1",
+        "generate-object-property": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimist": "^1.2.0",
+        "ndjson": "^1.4.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -611,6 +650,14 @@
       "optional": true,
       "requires": {
         "jsbn": "~0.1.0"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "^1.4.0"
       }
     },
     "error-ex": {
@@ -1009,11 +1056,32 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "generate-function": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/generate-function/-/generate-function-1.1.0.tgz",
+      "integrity": "sha1-VMIbCAGSsW2Yd3ecW7gWZudyNl8="
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -1167,8 +1235,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -1262,6 +1329,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -1289,8 +1361,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1592,6 +1663,34 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "ndjson": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
+      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^2.1.0",
+        "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "neat-csv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/neat-csv/-/neat-csv-3.0.0.tgz",
+      "integrity": "sha512-V6bNPsEPtsvIRWrXGj4U+NWtnvc7tU/i50oXJa7TaOLOTIbNGpuYg3RtFqW7Ziy9bMGWXfxqGGE4KxA5T8mS5A==",
+      "requires": {
+        "csv-parser": "^1.12.1",
+        "get-stream": "^4.0.0",
+        "to-readable-stream": "^1.0.0"
+      }
     },
     "nise": {
       "version": "1.4.2",
@@ -3713,7 +3812,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -3897,8 +3995,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "2.0.0",
@@ -3921,6 +4018,15 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "1.4.1",
@@ -3968,7 +4074,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -4197,6 +4302,14 @@
       "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
       "dev": true
     },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "requires": {
+        "through2": "^2.0.2"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4232,7 +4345,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -4304,6 +4416,15 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -4318,6 +4439,11 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
+    },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
     },
     "tough-cookie": {
       "version": "2.3.4",
@@ -4371,8 +4497,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.2",
@@ -4417,8 +4542,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",
@@ -4428,6 +4552,11 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "evrythng-extended": "^4.7.2",
     "evrythng-swagger": "^1.0.0",
     "json-schema-ref-parser": "^5.0.3",
-    "jsonschema": "^1.2.4"
+    "jsonschema": "^1.2.4",
+    "neat-csv": "^3.0.0"
   },
   "devDependencies": {
     "@evrythng/eslint-config-evrythng": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-jsdoc": "^3.7.1",
     "eslint-plugin-react": "^7.10.0",
+    "lodash": "^4.17.11",
     "mocha": "^5.2.0",
     "nyc": "^12.0.2",
     "sinon": "^6.1.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng-cli",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "CLI for the EVRYTHNG API.",
   "main": "./src/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "CLI for the EVRYTHNG API.",
   "main": "./src/main.js",
   "scripts": {

--- a/src/commands/action-type.js
+++ b/src/commands/action-type.js
@@ -22,8 +22,7 @@ module.exports = {
         return http.post('/actions', payload);
       },
       pattern: 'create $payload',
-      buildable: true,
-      importable: true,
+      helpPattern: 'create [$payload|--build|--from-csv]',
     },
     listActionType: {
       execute: async () => http.get('/actions'),

--- a/src/commands/action-type.js
+++ b/src/commands/action-type.js
@@ -3,7 +3,9 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
+const csv = require('../modules/csv');
 const http = require('../modules/http');
+const switches = require('../modules/switches');
 const util = require('../modules/util');
 
 module.exports = {
@@ -12,11 +14,16 @@ module.exports = {
   operations: {
     createActionType: {
       execute: async ([, json]) => {
+        if (switches.FROM_CSV) {
+          return csv.read('actionType');
+        }
+
         const payload = await util.getPayload('ActionTypeDocument', json);
         return http.post('/actions', payload);
       },
       pattern: 'create $payload',
       buildable: true,
+      importable: true,
     },
     listActionType: {
       execute: async () => http.get('/actions'),

--- a/src/commands/action.js
+++ b/src/commands/action.js
@@ -16,7 +16,7 @@ module.exports = {
         return http.post(`/actions/${type}`, payload);
       },
       pattern: '$type create $payload',
-      buildable: true,
+      helpPattern: '$type create [$payload|--build]',
     },
     listActions: {
       execute: async ([type]) => http.get(`/actions/${type}`),

--- a/src/commands/batch.js
+++ b/src/commands/batch.js
@@ -16,7 +16,7 @@ module.exports = {
         return http.post('/batches', payload);
       },
       pattern: 'create $payload',
-      buildable: true,
+      helpPattern: 'create [$payload|--build]',
     },
     readBatch: {
       execute: async ([id]) => http.get(`/batches/${id}`),
@@ -40,7 +40,7 @@ module.exports = {
         return http.post(`/batches/${id}/tasks`, payload);
       },
       pattern: '$id tasks create $payload',
-      buildable: true,
+      helpPattern: '$id tasks create [$payload|--build]',
     },
     listTasks: {
       execute: async ([id]) => http.get(`/batches/${id}/tasks`),

--- a/src/commands/collection.js
+++ b/src/commands/collection.js
@@ -3,7 +3,9 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
+const csv = require('../modules/csv');
 const http = require('../modules/http');
+const switches = require('../modules/switches');
 const util = require('../modules/util');
 
 module.exports = {
@@ -13,11 +15,16 @@ module.exports = {
     // CRUD
     createCollection: {
       execute: async ([, json]) => {
+        if (switches.FROM_CSV) {
+          return csv.read('collection');
+        }
+
         const payload = await util.getPayload('CollectionDocument', json);
         return http.post('/collections', payload);
       },
       pattern: 'create $payload',
       buildable: true,
+      importable: true,
     },
     readCollection: {
       execute: async ([id]) => http.get(`/collections/${id}`),

--- a/src/commands/collection.js
+++ b/src/commands/collection.js
@@ -23,8 +23,7 @@ module.exports = {
         return http.post('/collections', payload);
       },
       pattern: 'create $payload',
-      buildable: true,
-      importable: true,
+      helpPattern: 'create [$payload|--build|--from-csv]',
     },
     readCollection: {
       execute: async ([id]) => http.get(`/collections/${id}`),

--- a/src/commands/file.js
+++ b/src/commands/file.js
@@ -65,7 +65,7 @@ module.exports = {
         return http.post('/files', payload);
       },
       pattern: 'create $payload',
-      buildable: true,
+      helpPattern: 'create [$payload|--build]',
     },
     read: {
       execute: async ([id]) => http.get(`/files/${id}`),

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,0 +1,10 @@
+module.exports = {
+  about: 'See the help text, including usage examples.',
+  firstArg: 'help',
+  operations: {
+    printHelp: {
+      execute: () => require('../functions/printHelp')(),
+      pattern: '',
+    },
+  },
+};

--- a/src/commands/operator.js
+++ b/src/commands/operator.js
@@ -53,6 +53,21 @@ const showKey = ([name]) => {
 };
 
 /**
+ * Test an operator's credentials work, else throw.
+ *
+ * @async
+ * @param {String} region - User entered region.
+ * @param {String} apiKey - User entered API key.
+ */
+const validateCredentials = async (region, apiKey) => {
+  evrythng.setup({ apiUrl: REGIONS[region] });
+  const access = await evrythng.api({ url: '/access', authorization: apiKey });
+  if (access.actor.type !== 'operator') {
+    throw new Error('Actor was not operator');
+  }
+};
+
+/**
  * Add an operator record to the configuration, if it is valid.
  *
  * @async
@@ -71,11 +86,7 @@ const addOperator = async ([, name, region, apiKey]) => {
 
   // Check the key is valid
   try {
-    evrythng.setup({ apiUrl: REGIONS[region] });
-    const access = await evrythng.api({ url: '/access', authorization: apiKey });
-    if (access.actor.type !== 'operator') {
-      throw new Error('Actor was not operator');
-    }
+    await module.exports.validateCredentials(region, apiKey);
   } catch (e) {
     throw new Error('Failed to add operator - check $apiKey and $region are correct and compatible.');
   }
@@ -181,4 +192,5 @@ module.exports = {
   checkFirstRun,
   resolveKey,
   getCurrent,
+  validateCredentials,
 };

--- a/src/commands/operator.js
+++ b/src/commands/operator.js
@@ -77,7 +77,7 @@ const addOperator = async ([, name, region, apiKey]) => {
       throw new Error('Actor was not operator');
     }
   } catch (e) {
-    throw new Error('Failed to add operator - check apiKey and region are correct and compatible.');
+    throw new Error('Failed to add operator - check $apiKey and $region are correct and compatible.');
   }
 
   const operators = config.get('operators');

--- a/src/commands/operator.js
+++ b/src/commands/operator.js
@@ -135,7 +135,7 @@ const checkFirstRun = async () => {
   const name = await getValue('Short Operator name (e.g: \'personal\')');
   const region = await getValue('Account region (\'us\' or \'eu\')');
   const apiKey = await getValue('Operator API Key (from \'Account Settings\' in the EVRYTHNG Dashboard\')');
-  addOperator([null, name, region, apiKey]);
+  await addOperator([null, name, region, apiKey]);
 
   logger.info('\nYou\'re all set! Commands follow a \'resource type\' \'verb\' format. '
     + 'Some examples to get you started:\n');

--- a/src/commands/operator.js
+++ b/src/commands/operator.js
@@ -52,7 +52,13 @@ const showKey = ([name]) => {
   return key;
 };
 
-const addOperator = ([, name, region, apiKey]) => {
+/**
+ * Add an operator record to the configuration, if it is valid.
+ *
+ * @async
+ * @param {String[]} args - The command arguments provided.
+ */ 
+const addOperator = async ([, name, region, apiKey]) => {
   if (!REGIONS[region]) {
     throw new Error(`$region must be one of ${Object.keys(REGIONS).join(', ')}`);
   }
@@ -61,6 +67,17 @@ const addOperator = ([, name, region, apiKey]) => {
   }
   if (apiKey.length !== 80) {
     throw new Error('API key is an invalid length');
+  }
+
+  // Check the key is valid
+  try {
+    evrythng.setup({ apiUrl: REGIONS[region] });
+    const access = await evrythng.api({ url: '/access', authorization: apiKey });
+    if (access.actor.type !== 'operator') {
+      throw new Error('Actor was not operator');
+    }
+  } catch (e) {
+    throw new Error('Failed to add operator - check apiKey and region are correct and compatible.');
   }
 
   const operators = config.get('operators');

--- a/src/commands/operator.js
+++ b/src/commands/operator.js
@@ -55,9 +55,8 @@ const showKey = ([name]) => {
 /**
  * Test an operator's credentials work, else throw.
  *
- * @async
- * @param {String} region - User entered region.
- * @param {String} apiKey - User entered API key.
+ * @param {string} region - User entered region.
+ * @param {string} apiKey - User entered API key.
  */
 const validateCredentials = async (region, apiKey) => {
   evrythng.setup({ apiUrl: REGIONS[region] });
@@ -70,10 +69,10 @@ const validateCredentials = async (region, apiKey) => {
 /**
  * Add an operator record to the configuration, if it is valid.
  *
- * @async
- * @param {String[]} args - The command arguments provided.
- */ 
-const addOperator = async ([, name, region, apiKey]) => {
+ * @param {string[]} args - The command arguments provided.
+ */
+const addOperator = async (args) => {
+  const [, name, region, apiKey] = args;
   if (!REGIONS[region]) {
     throw new Error(`$region must be one of ${Object.keys(REGIONS).join(', ')}`);
   }

--- a/src/commands/place.js
+++ b/src/commands/place.js
@@ -22,8 +22,7 @@ module.exports = {
         return http.post('/places', payload);
       },
       pattern: 'create $payload',
-      buildable: true,
-      importable: true,
+      helpPattern: 'create [$payload|--build|--from-csv]',
     },
     read: {
       execute: async ([placeId]) => http.get(`/places/${placeId}`),

--- a/src/commands/place.js
+++ b/src/commands/place.js
@@ -3,7 +3,9 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
+const csv = require('../modules/csv');
 const http = require('../modules/http');
+const switches = require('../modules/switches');
 const util = require('../modules/util');
 
 module.exports = {
@@ -12,6 +14,10 @@ module.exports = {
   operations: {
     create: {
       execute: async ([, json]) => {
+        if (switches.FROM_CSV) {
+          return csv.read('place');
+        }
+
         const payload = await util.getPayload('PlaceDocument', json);
         return http.post('/places', payload);
       },

--- a/src/commands/place.js
+++ b/src/commands/place.js
@@ -23,6 +23,7 @@ module.exports = {
       },
       pattern: 'create $payload',
       buildable: true,
+      importable: true,
     },
     read: {
       execute: async ([placeId]) => http.get(`/places/${placeId}`),

--- a/src/commands/product.js
+++ b/src/commands/product.js
@@ -3,7 +3,9 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
+const csv = require('../modules/csv');
 const http = require('../modules/http');
+const switches = require('../modules/switches');
 const util = require('../modules/util');
 
 module.exports = {
@@ -13,11 +15,16 @@ module.exports = {
     // CRUD
     createProduct: {
       execute: async ([, json]) => {
+        if (switches.FROM_CSV) {
+          return csv.read('product');
+        }
+
         const payload = await util.getPayload('ProductDocument', json);
         return http.post('/products', payload);
       },
       pattern: 'create $payload',
       buildable: true,
+      importable: true,
     },
     readProduct: {
       execute: async ([id]) => http.get(`/products/${id}`),

--- a/src/commands/product.js
+++ b/src/commands/product.js
@@ -23,8 +23,7 @@ module.exports = {
         return http.post('/products', payload);
       },
       pattern: 'create $payload',
-      buildable: true,
-      importable: true,
+      helpPattern: 'create [$payload|--build|--from-csv]',
     },
     readProduct: {
       execute: async ([id]) => http.get(`/products/${id}`),

--- a/src/commands/project.js
+++ b/src/commands/project.js
@@ -17,7 +17,7 @@ module.exports = {
         return http.post('/projects', payload);
       },
       pattern: 'create $payload',
-      buildable: true,
+      helpPattern: 'create [$payload|--build]',
     },
     listProject: {
       execute: async () => http.get('/projects'),
@@ -43,7 +43,7 @@ module.exports = {
         return http.post(`/projects/${projectId}/applications`, payload);
       },
       pattern: '$id applications create $payload',
-      buildable: true,
+      helpPattern: '$id applications create [$payload|--build]',
     },
     listApplication: {
       execute: async ([projectId]) => http.get(`/projects/${projectId}/applications`),

--- a/src/commands/thng.js
+++ b/src/commands/thng.js
@@ -23,8 +23,7 @@ module.exports = {
         return http.post('/thngs', payload);
       },
       pattern: 'create $payload',
-      buildable: true,
-      importable: true,
+      helpPattern: 'create [$payload|--build|--from-csv]',
     },
     readThng: {
       execute: async ([id]) => http.get(`/thngs/${id}`),

--- a/src/commands/thng.js
+++ b/src/commands/thng.js
@@ -3,7 +3,9 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
+const csv = require('../modules/csv');
 const http = require('../modules/http');
+const switches = require('../modules/switches');
 const util = require('../modules/util');
 
 module.exports = {
@@ -13,11 +15,16 @@ module.exports = {
     // CRUD
     createThng: {
       execute: async ([, json]) => {
+        if (switches.FROM_CSV) {
+          return csv.read('thng');
+        }
+
         const payload = await util.getPayload('ThngDocument', json);
         return http.post('/thngs', payload);
       },
       pattern: 'create $payload',
       buildable: true,
+      importable: true,
     },
     readThng: {
       execute: async ([id]) => http.get(`/thngs/${id}`),

--- a/src/functions/printHelp.js
+++ b/src/functions/printHelp.js
@@ -92,5 +92,4 @@ module.exports = () => {
 
   logger.info('\nUsage Examples:\n');
   formatList(EXAMPLES, 'about', 'command', false);
-  logger.info();
 };

--- a/src/functions/printHelp.js
+++ b/src/functions/printHelp.js
@@ -87,7 +87,7 @@ module.exports = () => {
   formatList(switchList, 'name', 'about');
 
   logger.info('\nAvailable Options:\n');
-  logger.info(indent('Use \'option list\' to see option states.\n', 4));
+  logger.info(indent('Use \'options list\' to see current option states.\n', 4));
   formatList(OPTION_LIST, 'name', 'about');
 
   logger.info('\nUsage Examples:\n');

--- a/src/functions/printHelp.js
+++ b/src/functions/printHelp.js
@@ -21,7 +21,7 @@ const EXAMPLES = [{
   about: 'Read a page of Thngs',
 }, {
   command: 'thngs UpUxnWAXeMPNQraRaGmKQdHr read',
-  about: 'Read a known Thng',
+  about: 'Read a single Thng',
 }, {
   command: 'products create \'{"name": "My New Product"}\'',
   about: 'Create a new product',
@@ -31,6 +31,12 @@ const EXAMPLES = [{
 }, {
   command: 'thngs create --build',
   about: 'Interactively create a Thng',
+}, {
+  command: 'products list --per-page 100 --to-csv ./products.csv',
+  about: 'Save products to a CSV file',
+}, {
+  command: 'products create --from-csv ./products.csv --project UnghCKffVg8a9KwRwE5C9qBs',
+  about: 'Create products from a CSV file',
 }];
 
 const printVersion = () => logger.info(`\n${name} v${version}\n${description}`);

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -24,8 +24,9 @@ const COMMAND_SCHEMA = {
           additionalProperties: false,
           requried: ['pattern', 'execute'],
           properties: {
-            pattern: { type: 'string' },
             execute: { type: 'any' },
+            pattern: { type: 'string' },
+            helpPattern: { type: 'string' },
           },
         },
       },

--- a/src/modules/commands.js
+++ b/src/modules/commands.js
@@ -32,8 +32,8 @@ const COMMAND_LIST = [
 const showSyntax = (command) => {
   const { firstArg, operations } = command;
   const specs = Object.keys(operations).map((item) => {
-    const { pattern, buildable, importable } = operations[item];
-    return `evrythng ${firstArg} ${pattern} ${buildable ? '(or --build)' : ''} ${importable ? '(or --from-csv)' : ''}`;
+    const { pattern, helpPattern } = operations[item];
+    return `evrythng ${firstArg} ${helpPattern || pattern}`;
   });
 
   throw new Error(`Available operations for '${firstArg}':\n${specs.join('\n')}`);

--- a/src/modules/commands.js
+++ b/src/modules/commands.js
@@ -31,8 +31,8 @@ const COMMAND_LIST = [
 const showSyntax = (command) => {
   const { firstArg, operations } = command;
   const specs = Object.keys(operations).map((item) => {
-    const { pattern, buildable } = operations[item];
-    return `evrythng ${firstArg} ${pattern} ${buildable ? '(or --build)' : ''}`;
+    const { pattern, buildable, importable } = operations[item];
+    return `evrythng ${firstArg} ${pattern} ${buildable ? '(or --build)' : ''} ${importable ? '(or --from-csv)' : ''}`;
   });
 
   throw new Error(`Available operations for '${firstArg}':\n${specs.join('\n')}`);
@@ -44,7 +44,8 @@ const matchArg = (arg = '', spec) => {
     $id: val => val.length === 24,
     // Value must be JSON
     $payload: (val) => {
-      if (switches.BUILD) {
+      // Some switches work instead of a payload
+      if (switches.BUILD || switches.FROM_CSV) {
         return true;
       }
 

--- a/src/modules/commands.js
+++ b/src/modules/commands.js
@@ -15,6 +15,7 @@ const COMMAND_LIST = [
   require('../commands/batch'),
   require('../commands/collection'),
   require('../commands/file'),
+  require('../commands/help'),
   require('../commands/operator'),
   require('../commands/option'),
   require('../commands/place'),

--- a/src/modules/csv.js
+++ b/src/modules/csv.js
@@ -197,14 +197,12 @@ const createCsvData = (arr) => {
     ...object, ...address, ...customFields, ...identifiers, ...properties,
   ].join(',');
 
-  const rows = arr.map((item) => {
-    return objectToCells(item, object)
-      .concat(objectToCells(item.address, address))
-      .concat(objectToCells(item.customFields, customFields))
-      .concat(objectToCells(item.identifiers, identifiers))
-      .concat(objectToCells(item.properties, properties))
-      .join(',');
-  });
+  const rows = arr.map(item => objectToCells(item, object)
+    .concat(objectToCells(item.address, address))
+    .concat(objectToCells(item.customFields, customFields))
+    .concat(objectToCells(item.identifiers, identifiers))
+    .concat(objectToCells(item.properties, properties))
+    .join(','));
   return [columnHeaders, ...rows];
 };
 

--- a/src/modules/csv.js
+++ b/src/modules/csv.js
@@ -35,12 +35,12 @@ const READ_ONLY = [
   'createdByTask',
   'fn',
   'scopes',
-  'properties',
 ];
 
-/* Keys that are not currently supported */
-const UNSUPPORTED = [
+/* Keys that are array type */
+const CONVERTED_ARRAYS = [
   'photos',
+  'tags',
 ];
 
 /* Use a character other than ','' to encode lists */
@@ -105,8 +105,8 @@ const addCells = (obj = {}, objKeys) => objKeys.reduce((res, item) => {
     return res;
   }
 
-  // Handle 'tags'
-  if (key === 'tags' && value.length) {
+  // Handle Array types
+  if (CONVERTED_ARRAYS.includes(key) && value.length) {
     value = value.join(LIST_SEPARATOR);
   }
 
@@ -189,11 +189,6 @@ const rowToObject = (row, headers) => {
       return res;
     }
 
-    if (UNSUPPORTED.includes(key)) {
-      logger.info(`Skipping unsupported key: ${key}`);
-      return res;
-    }
-
     // Decode CSV comma escaping
     let value = cells[i].split('"').join('');
     if (value === '[object Object]') {
@@ -201,10 +196,9 @@ const rowToObject = (row, headers) => {
     }
 
     // Tags
-    //  TODO need to handle escaping quotes AND commas...
-    if (key === 'tags') {
-      value = value.split(LIST_SEPARATOR);
+    if (CONVERTED_ARRAYS.includes(key)) {
       if (value.length) {
+        value = value.split(LIST_SEPARATOR);
         res[key] = value;
       }
       return res;

--- a/src/modules/csv.js
+++ b/src/modules/csv.js
@@ -12,11 +12,10 @@ const util = require('./util');
 
 /* Keys that are expanded to individual columns, or do not make sense for CSV file. */
 const IGNORE = [
-  // Do not make sense
+  // SDK property
   'resource',
-  'collections',
 
-  // Not supported
+  // Object not currently supported
   'location',
 
   // Expanded
@@ -41,6 +40,7 @@ const READ_ONLY = [
 const CONVERTED_ARRAYS = [
   'photos',
   'tags',
+  'collections',
 ];
 
 /* Use a character other than ','' to encode lists */

--- a/src/modules/csv.js
+++ b/src/modules/csv.js
@@ -324,5 +324,7 @@ module.exports = {
   rowToObject,
   addPrefixKeyToObject,
   createCsvData,
+  encodeObject,
+  decodeObject,
   READ_ONLY,
 };

--- a/src/modules/csv.js
+++ b/src/modules/csv.js
@@ -15,10 +15,8 @@ const IGNORE = [
   // SDK property
   'resource',
 
-  // Object not currently supported
-  'location',
-
-  // Expanded
+  // Objects that are expanded later on into individual columns
+  'address',
   'properties',
   'customFields',
   'identifiers',
@@ -43,10 +41,14 @@ const CONVERTED_ARRAYS = [
   'collections',
 ];
 
-/* Use a character other than ','' to encode lists */
+/* Use a character other than ','' to encode lists and object pairs */
 const LIST_SEPARATOR = '|';
 
-/** Get de-deuplicated list of object keys of a specific type (denoted by prefix)
+/* Separates object key-value pairs */
+const PAIR_SEPARATOR = ':';
+
+/** Get de-duplicated list of object keys of a specific type (denoted by prefix)
+ *
  * @param {Object[]} arr - Array of objects to search for keys.
  * @param {String} prefix - Optional prefix when searching a sub-object.
  * @returns {String[]} - Array of keys found in the objects.
@@ -65,17 +67,19 @@ const getAllKeys = (arr, prefix) => {
 
 /**
  * Get all applicable column headers for all objects.
- * Object, 'customFields', 'identifiers', and 'properties' are supported as types.
+ *
+ * Object, 'address', 'customFields', 'identifiers', and 'properties' are supported as types.
  * @param {Object[]} arr - Array of objects to search for keys.
  * @returns {Object} Object containing a list of each kind of keys
  */
 const getColumnHeaders = (arr) => {
   const objKeys = getAllKeys(arr);
+  const addressKeys = getAllKeys(arr.map(item => item.address || {}), 'address');
   const cfKeys = getAllKeys(arr.map(item => item.customFields || {}), 'customFields');
   const idKeys = getAllKeys(arr.map(item => item.identifiers || {}), 'identifiers');
   const propKeys = getAllKeys(arr.map(item => item.properties || {}), 'properties');
 
-  return { objKeys, cfKeys, idKeys, propKeys };
+  return { objKeys, addressKeys, cfKeys, idKeys, propKeys };
 };
 
 /**
@@ -86,57 +90,108 @@ const getColumnHeaders = (arr) => {
 const esc = val => `"${String(val).split('"').join('""')}"`;
 
 /**
+ * Encode a single level object into a CSV compatible format.
+ *
+ * @param {Object} obj - The object to encode.
+ * @returns {String} The encoded form.
+ */
+const encodeObject = obj => {
+  const pairs = Object.keys(obj).map(key => `${key}:${obj[key]}`);
+  return `{${pairs.join(LIST_SEPARATOR)}}`;
+};
+
+/**
+ * Decode a single level object string from a CSV compatible format.
+ *
+ * @param {String} objStr - The object string to decode.
+ * @returns {Object} The decoded object.
+ */
+const decodeObject = objStr => objStr
+  .slice(1, objStr.length - 1)
+  .split(LIST_SEPARATOR)
+  .reduce((res, pair) => {
+    const [key, value] = pair.split(PAIR_SEPARATOR);
+    res[key] = value;
+    return res;
+  }, {});
+
+/**
  * Create row of cell values for each applicable key, else add empty cell (,).
+ *
  * @param {Object} obj - The object to convert to a row.
  * @param {String[]} objKeys - Array of object keys to use.
  * @returns {String[]} Array of cell values for this row.
  */
-const addCells = (obj = {}, objKeys) => objKeys.reduce((res, item) => {
-  // Handle any prefix
-  const key = item.includes('.') ? item.substring(item.indexOf('.') + 1) : item;
-  let value = obj[key];
-  if (value === '[object Object]') {
-    logger.info(`Warning: Object exporting not supported (key: ${item})`);
+const objectToCells = (obj, objKeys) => {
+    // If this object doesn't exist, add an empty cell for every key missing
+  if (!obj) {
+    const cells = [];
+    objKeys.forEach(item => cells.push(''));
+    return cells;
   }
 
-  // Empty cell
-  if (!value) {
-    res.push('');
+  // For each key, add the value as a cell to the array
+  return objKeys.reduce((res, item) => {
+    // Handle any prefix
+    const key = item.includes('.') ? item.split('.')[1] : item;
+    let value = obj[key];
+   
+    // Empty cell
+    if (!value) {
+      res.push('');
+      return res;
+    }
+
+    // Handle Array types
+    if (CONVERTED_ARRAYS.includes(key) && value.length) {
+      res.push(`"${value.join(LIST_SEPARATOR)}"`);
+      return res;
+    }
+
+    // Position - special case, encode with the separator
+    if (key === 'position') {
+      const [lon, lat] = obj.position.coordinates;
+      res.push(`"${lon}|${lat}"`);
+      return res;
+    }
+
+    // Other objects not supported
+    if (String(value).includes('[object Object]')) {
+      logger.info(`Warning: Object exporting not supported (key: ${item})`);
+      res.push(esc(value));
+      return res;
+    }
+
+    res.push(esc(value));
     return res;
-  }
-
-  // Handle Array types
-  if (CONVERTED_ARRAYS.includes(key) && value.length) {
-    value = value.join(LIST_SEPARATOR);
-  }
-
-  res.push(esc(value));
-  return res;
-}, []);
+  }, []);
+};
 
 /**
  * Create CSV data from input object array.
+ *
  * @param {Object[]} arr - Array of input objects to convert.
  * @returns {String[]} Array of CSV rows as strings.
  */
 const createCsvData = (arr) => {
-  const { objKeys, cfKeys, idKeys, propKeys } = getColumnHeaders(arr);
-  const columnHeaders = [...objKeys, ...cfKeys, ...idKeys, ...propKeys].join(',');
+  const { objKeys, addressKeys, cfKeys, idKeys, propKeys } = getColumnHeaders(arr);
+  const columnHeaders = [...objKeys, ...addressKeys, ...cfKeys, ...idKeys, ...propKeys].join(',');
 
   const rows = arr.map((item) => {
-    const { customFields, identifiers, properties } = item;
-    return [
-      addCells(item, objKeys),
-      addCells(customFields, cfKeys),
-      addCells(identifiers, idKeys),
-      addCells(properties, propKeys),
-    ].join(',');
+    const { customFields, address, identifiers, properties } = item;
+    let cells = objectToCells(item, objKeys);
+    cells = cells.concat(objectToCells(address, addressKeys));
+    cells = cells.concat(objectToCells(customFields, cfKeys));
+    cells = cells.concat(objectToCells(identifiers, idKeys));
+    cells = cells.concat(objectToCells(properties, propKeys));
+    return cells.join(',');
   });
   return [columnHeaders, ...rows];
 };
 
 /**
  * Write some array of EVRYTHNG objects to a CSV file.
+ *
  * @param {Object[]} arr - Array of objects to write to file.
  * @param {String} path - Path of the file to write.
  */
@@ -144,6 +199,7 @@ const write = (arr, path) => fs.writeFileSync(path, createCsvData(arr).join('\n'
 
 /**
  * Create a single resource from a data object.
+ *
  * @async
  * @param {Object} scope - evrythng.js Operator scope.
  * @param {Object} resource - The object to create as a resource.
@@ -176,7 +232,8 @@ const addPrefixKeyToObject = (obj, objKey, key, value) => {
 };
 
 /**
- * Convert a CSV row to an EVRYTHNG resource, using the CSV headers
+ * Convert a CSV row to an EVRYTHNG resource, using the CSV headers.
+ *
  * @param {String} row - The row to convert.
  * @param {String[]} headers - The CSV headers.
  * @returns {Object} - An object representation of this CSV row.
@@ -190,20 +247,26 @@ const rowToObject = (row, headers) => {
     }
 
     // Decode CSV comma escaping
-    let value = cells[i].split('"').join('');
+    const value = cells[i].split('"').join('');
+    
+    // Sub-objects are not supported
     if (value === '[object Object]') {
       logger.info(`Warning: Object importing not supported (key: ${key})`);
+      return res;
     }
 
     // Tags
     if (CONVERTED_ARRAYS.includes(key)) {
       if (value.length) {
-        value = value.split(LIST_SEPARATOR);
-        res[key] = value;
+        res[key] = value.split(LIST_SEPARATOR);
       }
       return res;
     }
 
+    // Sub-objects
+    if (key.includes('address')) {
+      return addPrefixKeyToObject(res, 'address', key, value);
+    }
     if (key.includes('customFields')) {
       return addPrefixKeyToObject(res, 'customFields', key, value);
     }
@@ -214,6 +277,16 @@ const rowToObject = (row, headers) => {
       return addPrefixKeyToObject(res, 'properties', key, value);
     }
 
+    // Position - special case, decode with the separator into fixed object
+    if (key === 'position') {
+      const [lon, lat] = value.split(LIST_SEPARATOR);
+      res[key] = {
+        type: 'Point',
+        coordinates: [parseFloat(lon), parseFloat(lat)],
+      };
+      return res;
+    }
+
     // Simple value
     res[key] = value;
     return res;
@@ -222,6 +295,7 @@ const rowToObject = (row, headers) => {
 
 /**
  * Read a CSV file and upload the contents to the account.
+ *
  * @async
  * @param {String} type - Type of EVRYTHNG resource the items in the file should be treated as.
  * @returns {Promise} A Promise that resolves when all items have been created.

--- a/src/modules/csv.js
+++ b/src/modules/csv.js
@@ -179,12 +179,12 @@ const createCsvData = (arr) => {
 
   const rows = arr.map((item) => {
     const { customFields, address, identifiers, properties } = item;
-    let cells = objectToCells(item, objKeys);
-    cells = cells.concat(objectToCells(address, addressKeys));
-    cells = cells.concat(objectToCells(customFields, cfKeys));
-    cells = cells.concat(objectToCells(identifiers, idKeys));
-    cells = cells.concat(objectToCells(properties, propKeys));
-    return cells.join(',');
+    return objectToCells(item, objKeys)
+      .concat(objectToCells(address, addressKeys))
+      .concat(objectToCells(customFields, cfKeys))
+      .concat(objectToCells(identifiers, idKeys))
+      .concat(objectToCells(properties, propKeys))
+      .join(',');
   });
   return [columnHeaders, ...rows];
 };

--- a/src/modules/csv.js
+++ b/src/modules/csv.js
@@ -44,6 +44,7 @@ const CONVERTED_ARRAYS = [
   'photos',
   'tags',
   'collections',
+  'categories',
 ];
 
 /* Use a character other than ','' to encode lists and object pairs */
@@ -293,6 +294,23 @@ const readCells = (row) => {
 };
 
 /**
+ * Preserve the type of a number or boolean that was extracted as a string token.
+ *
+ * @param {string} value - The string to process.
+ * @returns {string|number|boolean} The extracted value in its 'original' type.
+ */
+const preserveType = (value) => {
+  if (!isNaN(Number(value))) {
+    return Number(value);
+  }
+  if (['true', 'false'].includes(value)) {
+    return value === 'true';
+  }
+
+  return value;
+};
+
+/**
  * Convert a CSV row to an EVRYTHNG resource, using the CSV headers.
  *
  * @param {string} row - The row to convert.
@@ -308,7 +326,7 @@ const rowToObject = (row, headers) => {
     }
 
     // Decode CSV comma escaping
-    const value = cells[i].split('"').join('');
+    const value = preserveType(cells[i].split('"').join(''));
 
     // Sub-objects are not supported
     if (value === '[object Object]') {

--- a/src/modules/csv.js
+++ b/src/modules/csv.js
@@ -121,7 +121,7 @@ const addCells = (obj = {}, objKeys) => objKeys.reduce((res, item) => {
  */
 const createCsvData = (arr) => {
   const { objKeys, cfKeys, idKeys, propKeys } = getColumnHeaders(arr);
-  const columnHeaders = [...objKeys, ...cfKeys, ...idKeys, ...propKeys, ''].join(',');
+  const columnHeaders = [...objKeys, ...cfKeys, ...idKeys, ...propKeys].join(',');
 
   const rows = arr.map((item) => {
     const { customFields, identifiers, properties } = item;
@@ -165,7 +165,7 @@ const createResource = async (scope, resource, type) => {
   }
 };
 
-const addKeyToObject = (obj, objKey, key, value) => {
+const addPrefixKeyToObject = (obj, objKey, key, value) => {
   if (!obj[objKey]) {
     obj[objKey] = {};
   }
@@ -205,13 +205,13 @@ const rowToObject = (row, headers) => {
     }
 
     if (key.includes('customFields')) {
-      return addKeyToObject(res, 'customFields', key, value);
+      return addPrefixKeyToObject(res, 'customFields', key, value);
     }
     if (key.includes('identifiers')) {
-      return addKeyToObject(res, 'identifiers', key, value);
+      return addPrefixKeyToObject(res, 'identifiers', key, value);
     }
     if (key.includes('properties')) {
-      return addKeyToObject(res, 'properties', key, value);
+      return addPrefixKeyToObject(res, 'properties', key, value);
     }
 
     // Simple value
@@ -247,4 +247,8 @@ const read = async (type) => {
 module.exports = {
   write,
   read,
+  rowToObject,
+  addPrefixKeyToObject,
+  createCsvData,
+  READ_ONLY,
 };

--- a/src/modules/http.js
+++ b/src/modules/http.js
@@ -188,7 +188,7 @@ const printResponse = async (res) => {
   // Get just one field
   const field = switches.FIELD;
   if (field) {
-    logger.info(JSON.stringify(data[field], null, 2));
+    logger.info(JSON.stringify(data[field], null, INDENT_SIZE));
     return data[field];
   }
 

--- a/src/modules/http.js
+++ b/src/modules/http.js
@@ -14,6 +14,7 @@ const operator = require('../commands/operator');
 const switches = require('./switches');
 const util = require('./util');
 
+const INDENT_SIZE = 2;
 const TO_PAGE_MAX = 30;
 const STATUS_LABELS = {
   200: 'OK',
@@ -81,7 +82,7 @@ const printRequest = (options) => {
   formatHeaders(options.displayHeaders).forEach(item => logger.info(item));
   logger.info();
   if (options.data) {
-    logger.info(`${JSON.stringify(options.data, null, 2)}\n`);
+    logger.info(`${JSON.stringify(options.data, null, INDENT_SIZE)}\n`);
   }
 };
 

--- a/src/modules/http.js
+++ b/src/modules/http.js
@@ -187,13 +187,13 @@ const printResponse = async (res) => {
   // Get just one field
   const field = switches.FIELD;
   if (field) {
-    logger.info(data[field]);
+    logger.info(JSON.stringify(data[field], null, 2));
     return data[field];
   }
 
   // Print to file?
   if (csvFileName) {
-    csv.toFile(Array.isArray(data) ? data : [data], csvFileName);
+    csv.write(Array.isArray(data) ? data : [data], csvFileName);
     return res;
   }
 

--- a/src/modules/switches.js
+++ b/src/modules/switches.js
@@ -80,7 +80,7 @@ const apply = (args) => {
     .forEach((arg) => {
       const valid = SWITCH_LIST.find(({ name }) => name === arg);
       if (!valid) {
-        throw new Error(`Invalid switch: ${arg}`);
+        throw new Error(`Invalid switch: ${arg}.\nType 'evrythng help' to see a list of available switches.`);
       }
 
       const foundIndex = args.indexOf(arg);

--- a/src/modules/switches.js
+++ b/src/modules/switches.js
@@ -67,6 +67,11 @@ const SWITCH_LIST = [{
   about: 'Read up to 30 pages before returning results (only with --to-csv).',
   constant: 'TO_PAGE',
   valueLabel: '<page>',
+}, {
+  name: '--from-csv',
+  about: 'Load resources from a CSV file that was previously exported with --to-csv.',
+  constant: 'FROM_CSV',
+  valueLabel: '<input file>',
 }];
 
 const apply = (args) => {

--- a/src/modules/switches.js
+++ b/src/modules/switches.js
@@ -9,17 +9,31 @@ const SWITCH_LIST = [{
   constant: 'FILTER',
   valueLabel: '<query>',
 }, {
-  name: '--with-scopes',
-  about: 'Include resource scopes in the response.',
-  constant: 'SCOPES',
-}, {
   name: '--per-page',
   about: 'Specify number of resources per page.',
   constant: 'PER_PAGE',
   valueLabel: '<count>',
 }, {
+  name: '--project',
+  about: 'Specify the \'project\' query parameter.',
+  constant: 'PROJECT',
+  valueLabel: '<project ID>',
+}, {
+  name: '--with-scopes',
+  about: 'Include resource scopes in the response.',
+  constant: 'SCOPES',
+}, {
+  name: '--context',
+  about: 'Specify the \'context=true\' query parameter.',
+  constant: 'CONTEXT',
+}, {
+  name: '--page',
+  about: 'Iterate to a specific page of results.',
+  constant: 'PAGE',
+  valueLabel: '<page>',
+}, {
   name: '--summary',
-  about: 'Show a list of resources as a summarised single-line format',
+  about: 'Show a list of resources as a summarised (id, name) single-line format.',
   constant: 'SUMMARY',
 }, {
   name: '--api-key',
@@ -31,6 +45,10 @@ const SWITCH_LIST = [{
   about: 'Expand some ID fields, timestamps to date, etc.',
   constant: 'EXPAND',
 }, {
+  name: '--build',
+  about: 'Interactively build a create request payload using the EVRYTHNG Swagger API description.',
+  constant: 'BUILD',
+}, {
   name: '--field',
   about: 'Print only a certain field from the response.',
   constant: 'FIELD',
@@ -40,28 +58,10 @@ const SWITCH_LIST = [{
   about: 'Print response in non-JSON friendly format.',
   constant: 'SIMPLE',
 }, {
-  name: '--build',
-  about: 'Interactively build a create request payload using the EVRYTHNG Swagger API description.',
-  constant: 'BUILD',
-}, {
-  name: '--project',
-  about: 'Specify the \'project\' query parameter.',
-  constant: 'PROJECT',
-  valueLabel: '<project ID>',
-}, {
-  name: '--page',
-  about: 'Go to a specific page of results.',
-  constant: 'PAGE',
-  valueLabel: '<page>',
-}, {
   name: '--to-csv',
   about: 'Output array response to a CSV file, such as \'./data.csv\'.',
   constant: 'TO_CSV',
   valueLabel: '<output file>',
-}, {
-  name: '--context',
-  about: 'Specify the \'context=true\' query parameter.',
-  constant: 'CONTEXT',
 }, {
   name: '--to-page',
   about: 'Read up to 30 pages before returning results (only with --to-csv).',

--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -82,7 +82,7 @@ const validate = (instance, schema) => {
 
 /**
  * Sequentially run a series of functions that return Promises.
- * @async
+ *
  * @param {Function[]} items - Array of functions that return Promises.
  * @return {Promise} A Promise that resolves when all items have been processed.
  */

--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -80,6 +80,20 @@ const validate = (instance, schema) => {
   return errors.map(item => item.stack);
 };
 
+/**
+ * Sequentially run a series of functions that return Promises.
+ * @async
+ * @param {Function[]} items - Array of functions that return Promises.
+ * @return {Promise} A Promise that resolves when all items have been processed.
+ */
+const nextTask = async (items) => {
+  if (!items.length) {
+    return;
+  }
+
+  return items.splice(0, 1)[0]().then(() => nextTask(items));
+};
+
 module.exports = {
   isId,
   pretty,
@@ -88,4 +102,5 @@ module.exports = {
   printSimple,
   requireKey,
   validate,
+  nextTask,
 };

--- a/tests/commands/operator.js
+++ b/tests/commands/operator.js
@@ -5,9 +5,11 @@
 
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
+const sinon = require('sinon');
 const { ctx } = require('../util');
 const cli = require('../../src/functions/cli');
 const config = require('../../src/modules/config');
+const operator = require('../../src/commands/operator');
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -17,12 +19,15 @@ const { expect } = chai;
 describe('operators', () => {
   before(async () => {
     const res = await cli('operators list');
-
     ctx.using = res.using;
+
+    sinon.stub(operator, 'validateCredentials').returns(Promise.resolve());
   });
 
   after(async () => {
     await cli(`operators ${ctx.using} use`);
+
+    sinon.restore();
   });
 
   it('return object for \'operators add $name $region $apiKey\'', async () => {
@@ -60,5 +65,11 @@ describe('operators', () => {
 
   it('should not throw error for \'operators $name remove\'', async () => {
     return cli(`operators ${ctx.operatorName} remove`).should.be.fulfilled;
+  });
+
+  it('should throw error if operator credentials are not real', async () => {
+    sinon.restore();
+
+    return operator.validateCredentials('us', 'somebadapikey').should.be.rejected;
   });
 });

--- a/tests/commands/operator.js
+++ b/tests/commands/operator.js
@@ -11,7 +11,6 @@ const cli = require('../../src/functions/cli');
 const config = require('../../src/modules/config');
 const operator = require('../../src/commands/operator');
 
-chai.should();
 chai.use(chaiAsPromised);
 
 const { expect } = chai;
@@ -60,16 +59,17 @@ describe('operators', () => {
   });
 
   it('should not throw error for \'operators $name use\'', async () => {
-    return cli(`operators ${ctx.operatorName} use`).should.be.fulfilled;
+    await cli(`operators ${ctx.operatorName} use`);
   });
 
   it('should not throw error for \'operators $name remove\'', async () => {
-    return cli(`operators ${ctx.operatorName} remove`).should.be.fulfilled;
+    await cli(`operators ${ctx.operatorName} remove`);
   });
 
   it('should throw error if operator credentials are not real', async () => {
     sinon.restore();
 
-    return operator.validateCredentials('us', 'somebadapikey').should.be.rejected;
+    const validate = operator.validateCredentials('us', 'somebadapikey');
+    return expect(validate).to.eventually.be.rejected;
   });
 });

--- a/tests/modules/csv.js
+++ b/tests/modules/csv.js
@@ -4,7 +4,7 @@
  */
 
 const { expect } = require('chai');
-const _ = require('lodash');
+const { isEqual } = require('lodash');
 const fs = require('fs');
 const config = require('../../src/modules/config');
 const csv = require('../../src/modules/csv');
@@ -16,8 +16,12 @@ const TEST_OBJECTS = [{
   customFields: { foo: 'bar' },
   tags: ['some', 'tags'],
   product: 'UKGwQrgHq3shEqRaw2KyTt2n',
-  identifiers: { dm: '8742278493' },
-  properties: { color: 'red' },
+  identifiers: { storeCode: 'd29hf89' },
+  properties: { 
+    color: 'red', 
+    serial_number: 123,
+    is_active: true,
+  },
   collections: [
     'UH4nVsWVMG8EEqRawkMnybMh',
     'UHHHeHc5MGsYhqRawF6Hybgg',
@@ -41,10 +45,10 @@ const TEST_OBJECTS = [{
   name: 'Thng3',
 }];
 const TEST_ROWS = [
-  'id,name,tags,product,collections,position,address.street,address.city,address.countryCode,customFields.foo,customFields.baz,identifiers.dm,identifiers.gs1:21,properties.color',
-  'U5GSbgP7KwddXtRRwkwxYgPq,"Name, with commas",some|tags,UKGwQrgHq3shEqRaw2KyTt2n,UH4nVsWVMG8EEqRawkMnybMh|UHHHeHc5MGsYhqRawF6Hybgg,-0.119123|51.519435,East Road,London,GB,bar,,8742278493,,red',
-  'UpmSnYxUDDbasCwwRkRNQehq,Thng2,,,,,,,,,123,,4837289,',
-  'UK3x87gBpwAAXtawamsKRtmr,Thng3,,,,,,,,,,,,',
+  'id,name,tags,product,collections,position,address.street,address.city,address.countryCode,customFields.foo,customFields.baz,identifiers.storeCode,identifiers.gs1:21,properties.color,properties.serial_number,properties.is_active',
+  'U5GSbgP7KwddXtRRwkwxYgPq,"Name, with commas",some|tags,UKGwQrgHq3shEqRaw2KyTt2n,UH4nVsWVMG8EEqRawkMnybMh|UHHHeHc5MGsYhqRawF6Hybgg,-0.119123|51.519435,East Road,London,GB,bar,,d29hf89,,red,123,true',
+  'UpmSnYxUDDbasCwwRkRNQehq,Thng2,,,,,,,,,123,,4837289,,,',
+  'UK3x87gBpwAAXtawamsKRtmr,Thng3,,,,,,,,,,,,,,',
 ];
 
 describe('csv', () => {
@@ -54,7 +58,7 @@ describe('csv', () => {
 
   it('should convert objects to CSV rows', () => {
     const rows = csv.createCsvData(TEST_OBJECTS);
-    expect(_.isEqual(rows, TEST_ROWS)).to.equal(true);
+    expect(isEqual(rows, TEST_ROWS)).to.equal(true);
   });
 
   it('should not throw when writing to a CSV file', async () => {
@@ -98,8 +102,12 @@ describe('csv', () => {
       tags: [ 'some', 'tags' ],
       customFields: { foo: 'bar' },
       product: 'UKGwQrgHq3shEqRaw2KyTt2n',
-      properties: { color: 'red' },
-      identifiers: { dm: '8742278493' },
+      properties: { 
+        color: 'red', 
+        serial_number: 123,
+        is_active: true,
+      },
+      identifiers: { storeCode: 'd29hf89' },
       collections: [
         'UH4nVsWVMG8EEqRawkMnybMh',
         'UHHHeHc5MGsYhqRawF6Hybgg',
@@ -114,7 +122,7 @@ describe('csv', () => {
         countryCode: 'GB',
       },
     };
-    expect(_.isEqual(object, expected)).to.equal(true);
+    expect(isEqual(object, expected)).to.equal(true);
   });
 
   it('should encode a simple JSON object', () => {
@@ -127,6 +135,6 @@ describe('csv', () => {
     const objStr = '{foo:bar|baz:thng}';
     const expected = { foo: 'bar', 'baz': 'thng' };
     const result = csv.decodeObject(objStr);
-    expect(_.isEqual(result, expected)).to.equal(true);    
+    expect(isEqual(result, expected)).to.equal(true);    
   });
 });

--- a/tests/modules/csv.js
+++ b/tests/modules/csv.js
@@ -27,13 +27,12 @@ const TEST_OBJECTS = [{
   id: 'UK3x87gBpwAAXtawamsKRtmr',
   name: 'Thng3',
 }];
-const TEST_ROWS = [ 
+const TEST_ROWS = [
   'id,name,tags,product,customFields.foo,customFields.baz,identifiers.dm,identifiers.gs1:21,properties.color',
   '"U5GSbgP7KwddXtRRwkwxYgPq","Thng1","some|tags","UKGwQrgHq3shEqRaw2KyTt2n","bar",,"8742278493",,"red"',
   '"UpmSnYxUDDbasCwwRkRNQehq","Thng2",,,,"123",,"4837289",',
   '"UK3x87gBpwAAXtawamsKRtmr","Thng3",,,,,,,',
 ];
-const TEST_HEADERS = TEST_ROWS[0];
 
 describe('csv', () => {
   after(async () => {
@@ -52,11 +51,10 @@ describe('csv', () => {
 
   it('should have written the correct content to file', () => {
     const rows = fs.readFileSync(CSV_PATH, 'utf8').toString().split('\n');
-    expect(rows).to.have.length(4);
-    expect(rows[0]).to.equal(TEST_HEADERS);
-    expect(rows[1]).to.equal(TEST_ROWS[1]);
-    expect(rows[2]).to.equal(TEST_ROWS[2]);
-    expect(rows[3]).to.equal(TEST_ROWS[3]);
+    expect(rows).to.have.length(TEST_ROWS.length);
+    rows.forEach((item, i) => {
+      expect(rows[i]).to.equal(TEST_ROWS[i]);
+    });
   });
 
   it('should add a key to an object property', () => {
@@ -81,8 +79,8 @@ describe('csv', () => {
   });
 
   it('should convert a row into an object', () => {
-    const object = csv.rowToObject(TEST_ROWS[1], TEST_HEADERS.split(','));
-    const result = { 
+    const object = csv.rowToObject(TEST_ROWS[1], TEST_ROWS[0].split(','));
+    const result = {
       name: 'Thng1',
       tags: [ 'some', 'tags' ],
       customFields: { foo: 'bar' },

--- a/tests/modules/csv.js
+++ b/tests/modules/csv.js
@@ -18,6 +18,10 @@ const TEST_OBJECTS = [{
   product: 'UKGwQrgHq3shEqRaw2KyTt2n',
   identifiers: { dm: '8742278493' },
   properties: { color: 'red' },
+  collections: [
+    'UH4nVsWVMG8EEqRawkMnybMh',
+    'UHHHeHc5MGsYhqRawF6Hybgg',
+  ],
 }, {
   id: 'UpmSnYxUDDbasCwwRkRNQehq',
   name: 'Thng2',
@@ -28,10 +32,10 @@ const TEST_OBJECTS = [{
   name: 'Thng3',
 }];
 const TEST_ROWS = [
-  'id,name,tags,product,customFields.foo,customFields.baz,identifiers.dm,identifiers.gs1:21,properties.color',
-  '"U5GSbgP7KwddXtRRwkwxYgPq","Thng1","some|tags","UKGwQrgHq3shEqRaw2KyTt2n","bar",,"8742278493",,"red"',
-  '"UpmSnYxUDDbasCwwRkRNQehq","Thng2",,,,"123",,"4837289",',
-  '"UK3x87gBpwAAXtawamsKRtmr","Thng3",,,,,,,',
+  'id,name,tags,product,collections,customFields.foo,customFields.baz,identifiers.dm,identifiers.gs1:21,properties.color',
+  '"U5GSbgP7KwddXtRRwkwxYgPq","Thng1","some|tags","UKGwQrgHq3shEqRaw2KyTt2n","UH4nVsWVMG8EEqRawkMnybMh|UHHHeHc5MGsYhqRawF6Hybgg","bar",,"8742278493",,"red"',
+  '"UpmSnYxUDDbasCwwRkRNQehq","Thng2",,,,,"123",,"4837289",',
+  '"UK3x87gBpwAAXtawamsKRtmr","Thng3",,,,,,,,',
 ];
 
 describe('csv', () => {
@@ -87,6 +91,10 @@ describe('csv', () => {
       product: 'UKGwQrgHq3shEqRaw2KyTt2n',
       properties: { color: 'red' },
       identifiers: { dm: '8742278493' },
+      collections: [
+        'UH4nVsWVMG8EEqRawkMnybMh',
+        'UHHHeHc5MGsYhqRawF6Hybgg',
+      ],
     };
 
     expect(_.isEqual(object, result)).to.equal(true);

--- a/tests/modules/csv.js
+++ b/tests/modules/csv.js
@@ -22,6 +22,10 @@ const TEST_OBJECTS = [{
     'UH4nVsWVMG8EEqRawkMnybMh',
     'UHHHeHc5MGsYhqRawF6Hybgg',
   ],
+  position: {
+    type: 'Point',
+    coordinates: [ -0.119123, 51.519435 ],
+  },
 }, {
   id: 'UpmSnYxUDDbasCwwRkRNQehq',
   name: 'Thng2',
@@ -32,10 +36,10 @@ const TEST_OBJECTS = [{
   name: 'Thng3',
 }];
 const TEST_ROWS = [
-  'id,name,tags,product,collections,customFields.foo,customFields.baz,identifiers.dm,identifiers.gs1:21,properties.color',
-  '"U5GSbgP7KwddXtRRwkwxYgPq","Thng1","some|tags","UKGwQrgHq3shEqRaw2KyTt2n","UH4nVsWVMG8EEqRawkMnybMh|UHHHeHc5MGsYhqRawF6Hybgg","bar",,"8742278493",,"red"',
-  '"UpmSnYxUDDbasCwwRkRNQehq","Thng2",,,,,"123",,"4837289",',
-  '"UK3x87gBpwAAXtawamsKRtmr","Thng3",,,,,,,,',
+  'id,name,tags,product,collections,position,customFields.foo,customFields.baz,identifiers.dm,identifiers.gs1:21,properties.color',
+  '"U5GSbgP7KwddXtRRwkwxYgPq","Thng1","some|tags","UKGwQrgHq3shEqRaw2KyTt2n","UH4nVsWVMG8EEqRawkMnybMh|UHHHeHc5MGsYhqRawF6Hybgg","-0.119123|51.519435","bar",,"8742278493",,"red"',
+  '"UpmSnYxUDDbasCwwRkRNQehq","Thng2",,,,,,"123",,"4837289"',
+  '"UK3x87gBpwAAXtawamsKRtmr","Thng3",,,,',
 ];
 
 describe('csv', () => {
@@ -84,7 +88,7 @@ describe('csv', () => {
 
   it('should convert a row into an object', () => {
     const object = csv.rowToObject(TEST_ROWS[1], TEST_ROWS[0].split(','));
-    const result = {
+    const expected = {
       name: 'Thng1',
       tags: [ 'some', 'tags' ],
       customFields: { foo: 'bar' },
@@ -95,8 +99,11 @@ describe('csv', () => {
         'UH4nVsWVMG8EEqRawkMnybMh',
         'UHHHeHc5MGsYhqRawF6Hybgg',
       ],
+      position: {
+        type: 'Point',
+        coordinates: [ -0.119123, 51.519435 ],
+      },
     };
-
-    expect(_.isEqual(object, result)).to.equal(true);
+    expect(_.isEqual(object, expected)).to.equal(true);
   });
 });

--- a/tests/modules/csv.js
+++ b/tests/modules/csv.js
@@ -28,7 +28,7 @@ describe('csv', () => {
       name: 'Thng3',
     }];
     
-    const writeCsvFile = () => csv.toFile(data, CSV_PATH);
+    const writeCsvFile = () => csv.write(data, CSV_PATH);
     expect(writeCsvFile).to.not.throw();
 
     const rows = fs.readFileSync(CSV_PATH, 'utf8').toString().split('\n');

--- a/tests/modules/csv.js
+++ b/tests/modules/csv.js
@@ -12,7 +12,7 @@ const csv = require('../../src/modules/csv');
 const CSV_PATH = `${__dirname}/output.csv`;
 const TEST_OBJECTS = [{
   id: 'U5GSbgP7KwddXtRRwkwxYgPq',
-  name: 'Thng1',
+  name: 'Name, with commas',
   customFields: { foo: 'bar' },
   tags: ['some', 'tags'],
   product: 'UKGwQrgHq3shEqRaw2KyTt2n',
@@ -42,9 +42,9 @@ const TEST_OBJECTS = [{
 }];
 const TEST_ROWS = [
   'id,name,tags,product,collections,position,address.street,address.city,address.countryCode,customFields.foo,customFields.baz,identifiers.dm,identifiers.gs1:21,properties.color',
-  '"U5GSbgP7KwddXtRRwkwxYgPq","Thng1","some|tags","UKGwQrgHq3shEqRaw2KyTt2n","UH4nVsWVMG8EEqRawkMnybMh|UHHHeHc5MGsYhqRawF6Hybgg","-0.119123|51.519435","East Road","London","GB","bar",,"8742278493",,"red"',
-  '"UpmSnYxUDDbasCwwRkRNQehq","Thng2",,,,,,,,,"123",,"4837289",',
-  '"UK3x87gBpwAAXtawamsKRtmr","Thng3",,,,,,,,,,,,',
+  'U5GSbgP7KwddXtRRwkwxYgPq,"Name, with commas",some|tags,UKGwQrgHq3shEqRaw2KyTt2n,UH4nVsWVMG8EEqRawkMnybMh|UHHHeHc5MGsYhqRawF6Hybgg,-0.119123|51.519435,East Road,London,GB,bar,,8742278493,,red',
+  'UpmSnYxUDDbasCwwRkRNQehq,Thng2,,,,,,,,,123,,4837289,',
+  'UK3x87gBpwAAXtawamsKRtmr,Thng3,,,,,,,,,,,,',
 ];
 
 describe('csv', () => {
@@ -94,7 +94,7 @@ describe('csv', () => {
   it('should convert a row into an object', () => {
     const object = csv.rowToObject(TEST_ROWS[1], TEST_ROWS[0].split(','));
     const expected = {
-      name: 'Thng1',
+      name: 'Name, with commas',
       tags: [ 'some', 'tags' ],
       customFields: { foo: 'bar' },
       product: 'UKGwQrgHq3shEqRaw2KyTt2n',

--- a/tests/modules/csv.js
+++ b/tests/modules/csv.js
@@ -6,6 +6,7 @@
 const { expect } = require('chai');
 const { isEqual } = require('lodash');
 const fs = require('fs');
+const neatCsv = require('neat-csv');
 const config = require('../../src/modules/config');
 const csv = require('../../src/modules/csv');
 
@@ -95,8 +96,10 @@ describe('csv', () => {
     expect(simpleObj.customFields[realKey]).to.equal(testValue);
   });
 
-  it('should convert a row into an object', () => {
-    const object = csv.rowToObject(TEST_ROWS[1], TEST_ROWS[0].split(','));
+  it('should convert a row into an object', async () => {
+    const rowObjs = await neatCsv(TEST_ROWS.join('\n'));
+    const result = csv.rowToObject(rowObjs[0]);
+
     const expected = {
       name: 'Name, with commas',
       tags: [ 'some', 'tags' ],
@@ -122,7 +125,7 @@ describe('csv', () => {
         countryCode: 'GB',
       },
     };
-    expect(isEqual(object, expected)).to.equal(true);
+    expect(isEqual(result, expected)).to.equal(true);
   });
 
   it('should encode a simple JSON object', () => {
@@ -136,5 +139,28 @@ describe('csv', () => {
     const expected = { foo: 'bar', 'baz': 'thng' };
     const result = csv.decodeObject(objStr);
     expect(isEqual(result, expected)).to.equal(true);    
+  });
+
+  it('should manually read a CSV row', () => {
+    const expected = [ 
+      'U5GSbgP7KwddXtRRwkwxYgPq',
+      'Name, with commas',
+      'some|tags',
+      'UKGwQrgHq3shEqRaw2KyTt2n',
+      'UH4nVsWVMG8EEqRawkMnybMh|UHHHeHc5MGsYhqRawF6Hybgg',
+      '-0.119123|51.519435',
+      'East Road',
+      'London',
+      'GB',
+      'bar',
+      '',
+      'd29hf89',
+      '',
+      'red',
+      '123',
+      'true',
+    ];
+    const result = csv.readCells(TEST_ROWS[1]);
+    expect(isEqual(result, expected)).to.equal(true);
   });
 });

--- a/tests/modules/csv.js
+++ b/tests/modules/csv.js
@@ -26,6 +26,11 @@ const TEST_OBJECTS = [{
     type: 'Point',
     coordinates: [ -0.119123, 51.519435 ],
   },
+  address: {
+    street: 'East Road',
+    city: 'London',
+    countryCode: 'GB',
+  },
 }, {
   id: 'UpmSnYxUDDbasCwwRkRNQehq',
   name: 'Thng2',
@@ -36,10 +41,10 @@ const TEST_OBJECTS = [{
   name: 'Thng3',
 }];
 const TEST_ROWS = [
-  'id,name,tags,product,collections,position,customFields.foo,customFields.baz,identifiers.dm,identifiers.gs1:21,properties.color',
-  '"U5GSbgP7KwddXtRRwkwxYgPq","Thng1","some|tags","UKGwQrgHq3shEqRaw2KyTt2n","UH4nVsWVMG8EEqRawkMnybMh|UHHHeHc5MGsYhqRawF6Hybgg","-0.119123|51.519435","bar",,"8742278493",,"red"',
-  '"UpmSnYxUDDbasCwwRkRNQehq","Thng2",,,,,,"123",,"4837289"',
-  '"UK3x87gBpwAAXtawamsKRtmr","Thng3",,,,',
+  'id,name,tags,product,collections,position,address.street,address.city,address.countryCode,customFields.foo,customFields.baz,identifiers.dm,identifiers.gs1:21,properties.color',
+  '"U5GSbgP7KwddXtRRwkwxYgPq","Thng1","some|tags","UKGwQrgHq3shEqRaw2KyTt2n","UH4nVsWVMG8EEqRawkMnybMh|UHHHeHc5MGsYhqRawF6Hybgg","-0.119123|51.519435","East Road","London","GB","bar",,"8742278493",,"red"',
+  '"UpmSnYxUDDbasCwwRkRNQehq","Thng2",,,,,,,,,"123",,"4837289",',
+  '"UK3x87gBpwAAXtawamsKRtmr","Thng3",,,,,,,,,,,,',
 ];
 
 describe('csv', () => {
@@ -102,6 +107,11 @@ describe('csv', () => {
       position: {
         type: 'Point',
         coordinates: [ -0.119123, 51.519435 ],
+      },
+      address: {
+        street: 'East Road',
+        city: 'London',
+        countryCode: 'GB',
       },
     };
     expect(_.isEqual(object, expected)).to.equal(true);

--- a/tests/modules/csv.js
+++ b/tests/modules/csv.js
@@ -4,37 +4,93 @@
  */
 
 const { expect } = require('chai');
+const _ = require('lodash');
 const fs = require('fs');
 const config = require('../../src/modules/config');
 const csv = require('../../src/modules/csv');
 
 const CSV_PATH = `${__dirname}/output.csv`;
+const TEST_OBJECTS = [{
+  id: 'U5GSbgP7KwddXtRRwkwxYgPq',
+  name: 'Thng1',
+  customFields: { foo: 'bar' },
+  tags: ['some', 'tags'],
+  product: 'UKGwQrgHq3shEqRaw2KyTt2n',
+  identifiers: { dm: '8742278493' },
+  properties: { color: 'red' },
+}, {
+  id: 'UpmSnYxUDDbasCwwRkRNQehq',
+  name: 'Thng2',
+  customFields: { baz: 123 },
+  identifiers: { 'gs1:21': 4837289 },
+}, {
+  id: 'UK3x87gBpwAAXtawamsKRtmr',
+  name: 'Thng3',
+}];
+const TEST_ROWS = [ 
+  'id,name,tags,product,customFields.foo,customFields.baz,identifiers.dm,identifiers.gs1:21,properties.color',
+  '"U5GSbgP7KwddXtRRwkwxYgPq","Thng1","some|tags","UKGwQrgHq3shEqRaw2KyTt2n","bar",,"8742278493",,"red"',
+  '"UpmSnYxUDDbasCwwRkRNQehq","Thng2",,,,"123",,"4837289",',
+  '"UK3x87gBpwAAXtawamsKRtmr","Thng3",,,,,,,',
+];
+const TEST_HEADERS = TEST_ROWS[0];
 
 describe('csv', () => {
   after(async () => {
     fs.unlinkSync(CSV_PATH);
   });
 
-  it('should not throw writing a CSV file', async () => {
-    const data = [{ 
-      name: 'Thng1', 
-      customFields: { foo: 'bar' }, 
-      tags: ['some', 'tags'],
-    }, { 
-      name: 'Thng2', 
-      customFields: { baz: 123 }, 
-      identifiers: { 'gs1:21': 4837289 },
-    }, { 
-      name: 'Thng3',
-    }];
-    
-    const writeCsvFile = () => csv.write(data, CSV_PATH);
-    expect(writeCsvFile).to.not.throw();
+  it('should convert objects to CSV rows', () => {
+    const rows = csv.createCsvData(TEST_OBJECTS);
+    expect(_.isEqual(rows, TEST_ROWS)).to.equal(true);
+  });
 
+  it('should not throw when writing to a CSV file', async () => {
+    const writeCsvFile = () => csv.write(TEST_OBJECTS, CSV_PATH);
+    expect(writeCsvFile).to.not.throw();
+  });
+
+  it('should have written the correct content to file', () => {
     const rows = fs.readFileSync(CSV_PATH, 'utf8').toString().split('\n');
     expect(rows).to.have.length(4);
-    expect(rows[0]).to.equal('name,customFields.foo,customFields.baz,identifiers.gs1:21,');
-    expect(rows[1]).to.include(data[0].name);
-    expect(rows[2]).to.include(data[1].customFields.baz);
+    expect(rows[0]).to.equal(TEST_HEADERS);
+    expect(rows[1]).to.equal(TEST_ROWS[1]);
+    expect(rows[2]).to.equal(TEST_ROWS[2]);
+    expect(rows[3]).to.equal(TEST_ROWS[3]);
+  });
+
+  it('should add a key to an object property', () => {
+    const prefixKey = 'customFields.testKey';
+    const [, realKey] = prefixKey.split('.');
+    const testValue = 'testValue';
+    const simpleObj = { customFields: {} };
+
+    csv.addPrefixKeyToObject(simpleObj, 'customFields', prefixKey, testValue);
+    expect(simpleObj.customFields[realKey]).to.equal(testValue);
+  });
+
+  it('should add a key to a non-existent object property', () => {
+    const prefixKey = 'customFields.testKey';
+    const [, realKey] = prefixKey.split('.');
+    const testValue = 'testValue';
+    const simpleObj = {};
+
+    csv.addPrefixKeyToObject(simpleObj, 'customFields', prefixKey, testValue);
+    expect(simpleObj.customFields).to.be.an('object');
+    expect(simpleObj.customFields[realKey]).to.equal(testValue);
+  });
+
+  it('should convert a row into an object', () => {
+    const object = csv.rowToObject(TEST_ROWS[1], TEST_HEADERS.split(','));
+    const result = { 
+      name: 'Thng1',
+      tags: [ 'some', 'tags' ],
+      customFields: { foo: 'bar' },
+      product: 'UKGwQrgHq3shEqRaw2KyTt2n',
+      properties: { color: 'red' },
+      identifiers: { dm: '8742278493' },
+    };
+
+    expect(_.isEqual(object, result)).to.equal(true);
   });
 });

--- a/tests/modules/csv.js
+++ b/tests/modules/csv.js
@@ -76,7 +76,7 @@ describe('csv', () => {
     const testValue = 'testValue';
     const simpleObj = { customFields: {} };
 
-    csv.addPrefixKeyToObject(simpleObj, 'customFields', prefixKey, testValue);
+    csv.assignPrefixProperty(simpleObj, 'customFields', prefixKey, testValue);
     expect(simpleObj.customFields[realKey]).to.equal(testValue);
   });
 
@@ -86,7 +86,7 @@ describe('csv', () => {
     const testValue = 'testValue';
     const simpleObj = {};
 
-    csv.addPrefixKeyToObject(simpleObj, 'customFields', prefixKey, testValue);
+    csv.assignPrefixProperty(simpleObj, 'customFields', prefixKey, testValue);
     expect(simpleObj.customFields).to.be.an('object');
     expect(simpleObj.customFields[realKey]).to.equal(testValue);
   });

--- a/tests/modules/csv.js
+++ b/tests/modules/csv.js
@@ -116,4 +116,17 @@ describe('csv', () => {
     };
     expect(_.isEqual(object, expected)).to.equal(true);
   });
+
+  it('should encode a simple JSON object', () => {
+    const obj = { foo: 'bar', 'baz': 'thng' };
+    const expected = '{foo:bar|baz:thng}';
+    expect(csv.encodeObject(obj)).to.equal(expected);    
+  });
+
+  it('should decode a simple JSON object encoded string', () => {
+    const objStr = '{foo:bar|baz:thng}';
+    const expected = { foo: 'bar', 'baz': 'thng' };
+    const result = csv.decodeObject(objStr);
+    expect(_.isEqual(result, expected)).to.equal(true);    
+  });
 });

--- a/tests/modules/csv.js
+++ b/tests/modules/csv.js
@@ -140,27 +140,4 @@ describe('csv', () => {
     const result = csv.decodeObject(objStr);
     expect(isEqual(result, expected)).to.equal(true);    
   });
-
-  it('should manually read a CSV row', () => {
-    const expected = [ 
-      'U5GSbgP7KwddXtRRwkwxYgPq',
-      'Name, with commas',
-      'some|tags',
-      'UKGwQrgHq3shEqRaw2KyTt2n',
-      'UH4nVsWVMG8EEqRawkMnybMh|UHHHeHc5MGsYhqRawF6Hybgg',
-      '-0.119123|51.519435',
-      'East Road',
-      'London',
-      'GB',
-      'bar',
-      '',
-      'd29hf89',
-      '',
-      'red',
-      '123',
-      'true',
-    ];
-    const result = csv.readCells(TEST_ROWS[1]);
-    expect(isEqual(result, expected)).to.equal(true);
-  });
 });


### PR DESCRIPTION
_Features_
- Support import from CSV for many simple resources with `--from-csv`.
- Support export of place resources to CSV.
- Add missing `help` command.
- Add `runCommand()` method to plugin API.

_Fixes_
- `--field` now pretty-prints output.
- Validate new Operators added with `operators add` command work before adding to config.
- Improve error output when invalid switch is specified.