### PR TITLE
Convert E2E-style tests to unit-style tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -593,6 +593,12 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1715,6 +1721,40 @@
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
+      }
+    },
+    "nock": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.2.tgz",
+      "integrity": "sha512-uWrdlRzG28SXM5yqYsUHfYBRqljF8P6aTRDh6Y5kTgs/Q4GB59QWlpiegmDHQouvmX/rDyKkC/nk+k4nA+QPNw==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
       }
     },
     "normalize-package-data": {
@@ -4027,6 +4067,12 @@
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -21,15 +21,16 @@
     "neat-csv": "^3.0.0"
   },
   "devDependencies": {
-    "eslint-config-airbnb-base": "^13.0.0",
     "@evrythng/eslint-config-evrythng": "0.0.1",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "eslint": "^4.19.1",
+    "eslint-config-airbnb-base": "^13.0.0",
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-jsdoc": "^3.7.1",
     "eslint-plugin-react": "^7.10.0",
     "mocha": "^5.2.0",
+    "nock": "^10.0.2",
     "nyc": "^12.0.2",
     "sinon": "^6.1.4"
   },

--- a/src/commands/file.js
+++ b/src/commands/file.js
@@ -51,7 +51,7 @@ const upload = async (args) => {
   const { data: existing } = await http.get(`/files/${id}`, true);
   checkMetaDataMatches(existing, filePath, contentType);
 
-  uploadToS3(existing, fullPath, contentType);
+  module.exports.uploadToS3(existing, fullPath, contentType);
   logger.info(`File uploaded successfully.\nLocation: ${existing.contentUrl}`);
 };
 
@@ -84,4 +84,5 @@ module.exports = {
       pattern: '$id upload $file-path $mime-type',
     },
   },
+  uploadToS3,
 };

--- a/tests/commands/access.js
+++ b/tests/commands/access.js
@@ -3,14 +3,15 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
+const { mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
 describe('access', () => {
-  it('should return 200 for \'access read\'', async () => {
-    const res = await cli('access read');
+  it('should make correct request for \'access read\'', async () => {
+    mockApi()
+      .get('/access?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli('access read');
   });
 });

--- a/tests/commands/accesses.js
+++ b/tests/commands/accesses.js
@@ -3,56 +3,43 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
-const { ctx, createAppUser, createProject, createApplication } = require('../util');
+const { API_KEY, ID, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
-const operator = require('../../src/commands/operator');
 const switches = require('../../src/modules/switches');
 
 describe('accesses', () => {
-  before(async () => {
-    // Create project and application
-    ctx.project = await createProject();
-    ctx.application = await createApplication(ctx.project.id);
-
-    // Create Application Users for authentication and access sharing
-    ctx.appUser1 = await createAppUser('user1');
-    ctx.appUser2 = await createAppUser('user2');
+  afterEach(() => {
+    switches.API_KEY = false;
   });
 
-  after(async () => {
-    await cli(`app-users ${ctx.appUser1.evrythngUser} delete`);
-    await cli(`app-users ${ctx.appUser2.evrythngUser} delete`);
-    await cli(`projects ${ctx.project.id} delete`);
-  });
-
-  it('should return 201 for \'accesses create $payload\'', async () => {
+  it('should make correct request for \'accesses create $payload\'', async () => {
     const payload = JSON.stringify({
       email: `user2@example.com`,
       role: 'base_app_user',
     });
-    const res = await cli(`accesses create ${payload} --api-key ${ctx.appUser1.evrythngApiKey}`);
-    switches.API_KEY = false;
-
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.accessId = res.data.id;
+    mockApi()
+      .matchHeader('authorization', API_KEY)
+      .post('/accesses', payload)
+      .reply(201);
+    
+    await cli(`accesses create ${payload} --api-key ${API_KEY}`);
   });
 
-  it('should return 200 for \'accesses list\'', async () => {
-    const res = await cli(`accesses list --api-key ${ctx.appUser1.evrythngApiKey}`);
-    switches.API_KEY = false;
+  it('should make correct request for \'accesses list\'', async () => {
+    mockApi()
+      .matchHeader('authorization', API_KEY)
+      .get('/accesses?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`accesses list --api-key ${API_KEY}`);
   });
 
-  it('should return 204 for \'accesses delete\'', async () => {
-    const argStr = `accesses ${ctx.accessId} delete --api-key ${ctx.appUser1.evrythngApiKey}`;
-    const res = await cli(argStr);
-    switches.API_KEY = false;
+  it('should make correct request for \'accesses delete\'', async () => {
+    mockApi()
+      .matchHeader('authorization', API_KEY)
+      .delete(`/accesses/${ID}`)
+      .reply(204);
 
-    expect(res.status).to.equal(204);
+    await cli(`accesses ${ID} delete --api-key ${API_KEY}`);
   });
 });

--- a/tests/commands/account.js
+++ b/tests/commands/account.js
@@ -3,70 +3,73 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
-const { ctx } = require('../util');
+const { ID, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
 describe('accounts', () => {
-  it('should return 200 for \'accounts list\'', async () => {
-    const res = await cli('accounts list');
+  it('should make correct request for \'accounts list\'', async () => {
+    mockApi()
+      .get('/accounts?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
-
-    ctx.accountId = res.data[0].id;
+    await cli('accounts list');
   });
 
-  it('should return 200 for \'accounts $id read\'', async () => {
-    const res = await cli(`accounts ${ctx.accountId} read`);
+  it('should make correct request for \'accounts $id read\'', async () => {
+    mockApi()
+      .get(`/accounts/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`accounts ${ID} read`);
   });
 
-  it('should return 200 for \'accounts $id update $payload\'', async () => {
+  it('should make correct request for \'accounts $id update $payload\'', async () => {
+    mockApi()
+      .put(`/accounts/${ID}`)
+      .reply(200);
+
     const payload = JSON.stringify({ imageUrl: '' });
-    const res = await cli(`accounts ${ctx.accountId} update ${payload}`);
-
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`accounts ${ID} update ${payload}`);
   });
 
-  it('should return 200 for \'accounts $id accesses list\'', async () => {
-    const res = await cli(`accounts ${ctx.accountId} accesses list`);
+  it('should make correct request for \'accounts $id accesses list\'', async () => {
+    mockApi()
+      .get(`/accounts/${ID}/accesses?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
-
-    ctx.access = res.data[0];
+    await cli(`accounts ${ID} accesses list`);
   });
 
-  it('should return 200 for \'accounts $id accesses $id read\'', async () => {
-    const res = await cli(`accounts ${ctx.accountId} accesses ${ctx.access.id} read`);
+  it('should make correct request for \'accounts $id accesses $id read\'', async () => {
+    mockApi()
+      .get(`/accounts/${ID}/accesses/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`accounts ${ID} accesses ${ID} read`);
   });
 
-  it('should return 200 for \'accounts $id accesses $id update $payload\'', async () => {
-    const payload = JSON.stringify({ role: ctx.access.role });
-    const res = await cli(`accounts ${ctx.accountId} accesses ${ctx.access.id} update ${payload}`);
+  it('should make correct request for \'accounts $id accesses $id update $payload\'', async () => {
+    mockApi()
+      .put(`/accounts/${ID}/accesses/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    const payload = JSON.stringify({ role: ID });
+    await cli(`accounts ${ID} accesses ${ID} update ${payload}`);
   });
 
-  it('should return 200 for \'accounts $id domains list\'', async () => {
-    const res = await cli(`accounts ${ctx.accountId} domains list`);
+  it('should make correct request for \'accounts $id domains list\'', async () => {
+    mockApi()
+      .get(`/accounts/${ID}/domains?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`accounts ${ID} domains list`);
   });
 
-  it('should return 200 for \'accounts $id short-domains list\'', async () => {
-    const res = await cli(`accounts ${ctx.accountId} short-domains list`);
+  it('should make correct request for \'accounts $id short-domains list\'', async () => {
+    mockApi()
+      .get(`/accounts/${ID}/shortDomains?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`accounts ${ID} short-domains list`);
   });
 });

--- a/tests/commands/action-type.js
+++ b/tests/commands/action-type.js
@@ -3,39 +3,43 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
-const { ctx } = require('../util');
+const { mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
+const NAME = 'scans';
+
 describe('action-types', () => {
-  it('should return 201 for \'action-types create $payload\'', async () => {
+  it('should make correct request for \'action-types create $payload\'', async () => {
     const payload = JSON.stringify({ name: `_action-type-${Date.now()}` });
-    const res = await cli(`action-types create ${payload}`);
+    mockApi()
+      .post('/actions', payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.actionType = res.data.name;
+    await cli(`action-types create ${payload}`);
   });
 
-  it('should return 200 for \'action-types list\'', async () => {
-    const res = await cli('action-types list');
+  it('should make correct request for \'action-types list\'', async () => {
+    mockApi()
+      .get('/actions?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('action-types list');
   });
 
-  it('should return 200 for \'action-types $type update $payload\'', async () => {
+  it('should make correct request for \'action-types $type update $payload\'', async () => {
     const payload = JSON.stringify({ description: 'Example action type' });
-    const res = await cli(`action-types ${ctx.actionType} update ${payload}`);
+    mockApi()
+      .put(`/actions/${NAME}`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`action-types ${NAME} update ${payload}`);
   });
 
-  it('should return 200 for \'action-types $type delete\'', async () => {
-    const res = await cli(`action-types ${ctx.actionType} delete`);
+  it('should make correct request for \'action-types $type delete\'', async () => {
+    mockApi()
+      .delete(`/actions/${NAME}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`action-types ${NAME} delete`);
   });
 });

--- a/tests/commands/action.js
+++ b/tests/commands/action.js
@@ -3,49 +3,40 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
-const { ctx } = require('../util');
+const { NAME, ID, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
 describe('actions', () => {
-  before(async () => {
-    const payload = JSON.stringify({ name: `_action-type-${Date.now()}` });
-    const res = await cli(`action-types create ${payload}`);
-
-    ctx.actionType = res.data.name;
+  it('should make correct request for \'actions $type create $payload\'', async () => {
+    const payload = JSON.stringify({ type: NAME });
+    mockApi()
+      .post(`/actions/${NAME}`, payload)
+      .reply(201);
+    
+    await cli(`actions ${NAME} create ${payload}`);
   });
 
-  after(async () => {
-    await cli(`action-types ${ctx.actionType} delete`);
+  it('should make correct request for \'actions $type list\'', async () => {
+    mockApi()
+      .get(`/actions/${NAME}?perPage=30`)
+      .reply(200);
+
+    await cli(`actions ${NAME} list`);
   });
 
-  it('should return 201 for \'actions $type create $payload\'', async () => {
-    const payload = JSON.stringify({ type: ctx.actionType });
-    const res = await cli(`actions ${ctx.actionType} create ${payload}`);
-
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.actionId = res.data.id;
+  it('should make correct request for \'actions $type $id read\'', async () => {
+    mockApi()
+      .get(`/actions/${NAME}/${ID}`)
+      .reply(200);
+    
+    await cli(`actions ${NAME} ${ID} read`);
   });
 
-  it('should return 200 for \'actions $type list\'', async () => {
-    const res = await cli(`actions ${ctx.actionType} list`);
-
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
-  });
-
-  it('should return 200 for \'actions $type $id read\'', async () => {
-    const res = await cli(`actions ${ctx.actionType} ${ctx.actionId} read`);
-
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
-  });
-
-  it('should return 200 for \'actions $type $id delete\'', async () => {
-    const res = await cli(`actions ${ctx.actionType} ${ctx.actionId} delete`);
-
-    expect(res.status).to.equal(200);
+  it('should make correct request for \'actions $type $id delete\'', async () => {
+    mockApi()
+      .delete(`/actions/${NAME}/${ID}`)
+      .reply(200);
+      
+    await cli(`actions ${NAME} ${ID} delete`);
   });
 });

--- a/tests/commands/app-user.js
+++ b/tests/commands/app-user.js
@@ -3,11 +3,11 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
-const { ctx, createProject, createApplication } = require('../util');
+const { ID, API_KEY, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 const switches = require('../../src/modules/switches');
 
+const ACTIVATION_CODE = '843nxnun';
 const APP_USER = {
   firstName: 'test',
   lastName: 'user',
@@ -16,92 +16,89 @@ const APP_USER = {
 };
 
 describe('app-users', () => {
-  before(async () => {
-    ctx.project = await createProject();
-    ctx.application = await createApplication(ctx.project.id);
+  afterEach(() => {
+    switches.API_KEY = false;
   });
 
-  after(async () => {
-    await cli(`projects ${ctx.project.id} delete`);
-  });
-
-  it('should return 201 for \'app-users create $payload\'', async () => {
+  it('should make correct request for \'app-users create $payload\'', async () => {
     const payload = JSON.stringify(APP_USER);
-    const res = await cli(`app-users create ${payload} --api-key ${ctx.application.appApiKey}`);
-    switches.API_KEY = false;
+    mockApi()
+      .matchHeader('authorization', API_KEY)
+      .post('/auth/evrythng/users', payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.evrythngUser = res.data.evrythngUser;
-    ctx.activationCode = res.data.activationCode;
+    await cli(`app-users create ${payload} --api-key ${API_KEY}`);
   });
 
-  it('should return 201 for \'app-users $id validate $payload\'', async () => {
-    const payload = JSON.stringify({ activationCode: ctx.activationCode });
-    const argStr = `app-users ${ctx.evrythngUser} validate ${payload} --api-key ${ctx.application.appApiKey}`;
-    const res = await cli(argStr);
-    switches.API_KEY = false;
+  it('should make correct request for \'app-users $id validate $payload\'', async () => {
+    const payload = JSON.stringify({ activationCode: ACTIVATION_CODE });
+    mockApi()
+      .matchHeader('authorization', API_KEY)
+      .post(`/auth/evrythng/users/${ID}/validate`, payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.evrythngApiKey = res.data.evrythngApiKey;
+    await cli(`app-users ${ID} validate ${payload} --api-key ${API_KEY}`);
   });
 
-  it('should return 201 for \'app-users anonymous create\'', async () => {
-    const res = await cli(`app-users anonymous create --api-key ${ctx.application.appApiKey}`);
-    switches.API_KEY = false;
+  it('should make correct request for \'app-users anonymous create\'', async () => {
+    const payload = JSON.stringify({ anonymous: true });
+    mockApi()
+      .matchHeader('authorization', API_KEY)
+      .post('/auth/evrythng/users?anonymous=true', payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
+    await cli(`app-users anonymous create --api-key ${API_KEY}`);
   });
 
-  it('should return 200 for \'app-users list\'', async () => {
-    const res = await cli('app-users list');
+  it('should make correct request for \'app-users list\'', async () => {
+    mockApi()
+      .get('/users?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('app-users list');
   });
 
-  it('should return 200 for \'app-users $id read\'', async () => {
-    const res = await cli(`app-users ${ctx.evrythngUser} read`);
+  it('should make correct request for \'app-users $id read\'', async () => {
+    mockApi()
+      .get(`/users/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`app-users ${ID} read`);
   });
 
-  it('should return 200 for \'app-users $id update $payload\'', async () => {
+  it('should make correct request for \'app-users $id update $payload\'', async () => {
     const payload = JSON.stringify({ firstName: 'Test '});
-    const res = await cli(`app-users ${ctx.evrythngUser} update ${payload}`);
+    mockApi()
+      .put(`/users/${ID}`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`app-users ${ID} update ${payload}`);
   });
 
-  it('should return 200 for \'app-users login $payload\'', async () => {
-    const payload = JSON.stringify({
-      email: APP_USER.email,
-      password: APP_USER.password,
-    });
-    const res = await cli(`app-users login ${payload} --api-key ${ctx.application.appApiKey}`);
-    switches.API_KEY = false;
-
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+  it('should make correct request for \'app-users login $payload\'', async () => {
+    const payload = JSON.stringify({ email: APP_USER.email, password: APP_USER.password });
+    mockApi()
+      .matchHeader('authorization', API_KEY)
+      .post('/users/login', payload)
+      .reply(200);    
+    
+    await cli(`app-users login ${payload} --api-key ${API_KEY}`);
   });
 
-  it('should return 201 for \'app-users logout\'', async () => {
-    const res = await cli(`app-users logout --api-key ${ctx.evrythngApiKey}`);
-    switches.API_KEY = false;
+  it('should make correct request for \'app-users logout\'', async () => {
+    mockApi()
+      .matchHeader('authorization', API_KEY)
+      .post('/auth/all/logout')
+      .reply(200);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
+    await cli(`app-users logout --api-key ${API_KEY}`);
   });
 
-  it('should return 200 for \'app-users $id delete\'', async () => {
-    const res = await cli(`app-users ${ctx.evrythngUser} delete`);
+  it('should make correct request for \'app-users $id delete\'', async () => {
+    mockApi()
+      .delete(`/users/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`app-users ${ID} delete`);
   });
 });

--- a/tests/commands/batch.js
+++ b/tests/commands/batch.js
@@ -3,51 +3,45 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
-const { ctx } = require('../util');
+const { ID, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
-const readTasks = async () => cli(`batches ${ctx.batchId} tasks list`);
-
-const waitForTaskCompletion = async () => {
-  let res = await readTasks();
-  while (res.data[0].status !== 'EXECUTED') res = await readTasks();
-};
-
 describe('batches', async () => {
-  it('should return 201 for \'batches create $payload\'', async () => {
+  it('should make correct request for \'batches create $payload\'', async () => {
     const payload = JSON.stringify({ name: 'Test batch' });
-    const res = await cli(`batches create ${payload}`);
+    mockApi()
+      .post('/batches', payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.batchId = res.data.id;
+    await cli(`batches create ${payload}`);
   });
 
-  it('should return 200 for \'batches list\'', async () => {
-    const res = await cli('batches list');
+  it('should make correct request for \'batches list\'', async () => {
+    mockApi()
+      .get('/batches?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('batches list');
   });
 
-  it('should return 200 for \'batches $id read\'', async () => {
-    const res = await cli(`batches ${ctx.batchId} read`);
+  it('should make correct request for \'batches $id read\'', async () => {
+    mockApi()
+      .get(`/batches/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`batches ${ID} read`);
   });
 
-  it('should return 200 for \'batches $id update $payload\'', async () => {
+  it('should make correct request for \'batches $id update $payload\'', async () => {
     const payload = JSON.stringify({ description: 'Updated description' });
-    const res = await cli(`batches ${ctx.batchId} update ${payload}`);
+    mockApi()
+      .put(`/batches/${ID}`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`batches ${ID} update ${payload}`);
   });
 
-  it('should return 202 for \'batches $id tasks create $payload\'', async () => {
+  it('should make correct request for \'batches $id tasks create $payload\'', async () => {
     const payload = JSON.stringify({
       type: 'SHORT_ID_GENERATION',
       inputParameters: {
@@ -61,38 +55,42 @@ describe('batches', async () => {
         },
       },
     });
-    const res = await cli(`batches ${ctx.batchId} tasks create ${payload}`);
+    mockApi()
+      .post(`/batches/${ID}/tasks`, payload)
+      .reply(202);
 
-    expect(res.status).to.equal(202);
-
-    await waitForTaskCompletion();
+    await cli(`batches ${ID} tasks create ${payload}`);
   });
 
-  it('should return 200 for \'batches $id tasks list\'', async () => {
-    const res = await cli(`batches ${ctx.batchId} tasks list`);
+  it('should make correct request for \'batches $id tasks list\'', async () => {
+    mockApi()
+      .get(`/batches/${ID}/tasks?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
-
-    ctx.taskId = res.data[0].id;
+    await cli(`batches ${ID} tasks list`);
   });
 
-  it('should return 200 for \'batches $id tasks $id read\'', async () => {
-    const res = await cli(`batches ${ctx.batchId} tasks ${ctx.taskId} read`);
+  it('should make correct request for \'batches $id tasks $id read\'', async () => {
+    mockApi()
+      .get(`/batches/${ID}/tasks/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`batches ${ID} tasks ${ID} read`);
   });
 
-  it('should return 200 for \'batches $id tasks $id logs list\'', async () => {
-    const res = await cli(`batches ${ctx.batchId} tasks ${ctx.taskId} logs list`);
+  it('should make correct request for \'batches $id tasks $id logs list\'', async () => {
+    mockApi()
+      .get(`/batches/${ID}/tasks/${ID}/logs?perPage=30`)
+      .reply(200);
 
-    expect(res.data).to.be.an('array');
+    await cli(`batches ${ID} tasks ${ID} logs list`);
   });
 
-  it('should return 200 for \'batches $id delete\'', async () => {
-    const res = await cli(`batches ${ctx.batchId} delete`);
+  it('should make correct request for \'batches $id delete\'', async () => {
+    mockApi()
+      .delete(`/batches/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`batches ${ID} delete`);
   });
 });

--- a/tests/commands/collection.js
+++ b/tests/commands/collection.js
@@ -3,149 +3,140 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
-const { ctx } = require('../util');
+const { NAME, ID, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
 describe('collections', () => {
-  before(async () => {
-    let payload = JSON.stringify({ name: `_action-type-${Date.now()}` });
-    let res = await cli(`action-types create ${payload}`);
-
-    ctx.actionType = res.data.name;
-
-    payload = JSON.stringify({ name: 'Child collection' });
-    res = await cli(`collections create ${payload}`);
-
-    ctx.childId = res.data.id;
-
-    res = await cli('thngs list');
-    ctx.thngId = res.data[0].id;
-  });
-
-  after(async () => {
-    await cli(`action-types ${ctx.actionType} delete`);
-    await cli(`collections ${ctx.childId} delete`);
-  });
-
-  it('should return 201 for \'collections create $payload\'', async () => {
+  it('should make correct request for \'collections create $payload\'', async () => {
     const payload = JSON.stringify({ name: 'Test collection' });
-    const res = await cli(`collections create ${payload}`);
+    mockApi()
+      .post('/collections', payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.parentId = res.data.id;
+    await cli(`collections create ${payload}`);
   });
 
-  it('should return 200 for \'collections list\'', async () => {
-    const res = await cli('collections list');
+  it('should make correct request for \'collections list\'', async () => {
+    mockApi()
+      .get('/collections?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('collections list');
   });
 
-  it('should return 200 for \'collections $id read\'', async () => {
-    const res = await cli(`collections ${ctx.parentId} read`);
+  it('should make correct request for \'collections $id read\'', async () => {
+    mockApi()
+      .get(`/collections/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`collections ${ID} read`);
   });
 
-  it('should return 200 for \'collections $id update $payload\'', async () => {
+  it('should make correct request for \'collections $id update $payload\'', async () => {
     const payload = JSON.stringify({ description: 'Updated description' });
-    const res = await cli(`collections ${ctx.parentId} update ${payload}`);
+    mockApi()
+      .put(`/collections/${ID}`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`collections ${ID} update ${payload}`);
   });
 
-  it('should return 201 for \'collections $id actions create $payload\'', async () => {
-    const payload = JSON.stringify({ type: ctx.actionType });
-    const res = await cli(`collections ${ctx.parentId} actions create ${payload}`);
+  it('should make correct request for \'collections $id actions create $payload\'', async () => {
+    const payload = JSON.stringify({ type: NAME });
+    mockApi()
+      .post(`/collections/${ID}/actions/all`, payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.actionId = res.data.id;
+    await cli(`collections ${ID} actions create ${payload}`);
   });
 
-  it('should return 200 for \'collections $id actions list\'', async () => {
-    const res = await cli(`collections ${ctx.parentId} actions list`);
+  it('should make correct request for \'collections $id actions list\'', async () => {
+    mockApi()
+      .get(`/collections/${ID}/actions/all?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`collections ${ID} actions list`);
   });
 
-  it('should return 200 for \'collections $id actions $id read\'', async () => {
-    const res = await cli(`collections ${ctx.parentId} actions ${ctx.actionId} read`);
+  it('should make correct request for \'collections $id actions $id read\'', async () => {
+    mockApi()
+      .get(`/collections/${ID}/actions/all/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`collections ${ID} actions ${ID} read`);
   });
 
-  it('should return 200 for \'collections $id collections add $payload\'', async () => {
-    const payload = JSON.stringify([ctx.childId]);
-    const res = await cli(`collections ${ctx.parentId} collections add ${payload}`);
+  it('should make correct request for \'collections $id collections add $payload\'', async () => {
+    const payload = JSON.stringify([ID]);
+    mockApi()
+      .post(`/collections/${ID}/collections`, payload)
+      .reply(201);
 
-    expect(res.status).to.equal(200);
+    await cli(`collections ${ID} collections add ${payload}`);
   });
 
-  it('should return 200 for \'collections $id collections list\'', async () => {
-    const res = await cli(`collections ${ctx.parentId} collections list`);
+  it('should make correct request for \'collections $id collections list\'', async () => {
+    mockApi()
+      .get(`/collections/${ID}/collections?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`collections ${ID} collections list`);
   });
 
-  it('should return 200 for \'collections $id collections $id delete\'', async () => {
-    const res = await cli(`collections ${ctx.parentId} collections ${ctx.childId} delete`);
+  it('should make correct request for \'collections $id collections $id delete\'', async () => {
+    mockApi()
+      .delete(`/collections/${ID}/collections/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-
-    // Add again for the next test
-    const payload = JSON.stringify([ctx.childId]);
-    await cli(`collections ${ctx.parentId} collections add ${payload}`);
+    await cli(`collections ${ID} collections ${ID} delete`);
   });
 
-  it('should return 200 for \'collections $id collections delete\'', async () => {
-    const res = await cli(`collections ${ctx.parentId} collections delete`);
+  it('should make correct request for \'collections $id collections delete\'', async () => {
+    mockApi()
+      .delete(`/collections/${ID}/collections`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`collections ${ID} collections delete`);
   });
 
-  it('should return 200 for \'collections $id thngs add $payload\'', async () => {
-    const payload = JSON.stringify([ctx.thngId]);
-    const res = await cli(`collections ${ctx.parentId} thngs add ${payload}`);
+  it('should make correct request for \'collections $id thngs add $payload\'', async () => {
+    const payload = JSON.stringify([ID]);
+    mockApi()
+      .put(`/collections/${ID}/thngs`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`collections ${ID} thngs add ${payload}`);
   });
 
-  it('should return 200 for \'collections $id thngs list\'', async () => {
-    const res = await cli(`collections ${ctx.parentId} thngs list`);
+  it('should make correct request for \'collections $id thngs list\'', async () => {
+    mockApi()
+      .get(`/collections/${ID}/thngs?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`collections ${ID} thngs list`);
   });
 
-  it('should return 200 for \'collections $id thngs $id delete\'', async () => {
-    const res = await cli(`collections ${ctx.parentId} thngs ${ctx.thngId} delete`);
+  it('should make correct request for \'collections $id thngs $id delete\'', async () => {
+    mockApi()
+      .delete(`/collections/${ID}/thngs/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-
-    // Add again for the next test
-    const payload = JSON.stringify([ctx.thngId]);
-    await cli(`collections ${ctx.parentId} thngs add ${payload}`);
+    await cli(`collections ${ID} thngs ${ID} delete`);
   });
 
-  it('should return 200 for \'collections $id thngs delete\'', async () => {
-    const res = await cli(`collections ${ctx.parentId} thngs delete`);
+  it('should make correct request for \'collections $id thngs delete\'', async () => {
+    mockApi()
+      .delete(`/collections/${ID}/thngs`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`collections ${ID} thngs delete`);
   });
 
-  it('should return 200 for \'collections $id delete\'', async () => {
-    const res = await cli(`collections ${ctx.parentId} delete`);
+  it('should make correct request for \'collections $id delete\'', async () => {
+    mockApi()
+      .delete(`/collections/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`collections ${ID} delete`);
   });
 });

--- a/tests/commands/place.js
+++ b/tests/commands/place.js
@@ -3,46 +3,49 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
-const { ctx } = require('../util');
+const { ID, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
 describe('places', () => {
-  it('should return 201 for \'places create $payload\'', async () => {
+  it('should make correct request for \'places create $payload\'', async () => {
     const payload = JSON.stringify({ name: 'Test place' });
-    const res = await cli(`places create ${payload}`);
+    mockApi()
+      .post('/places', payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.placeId = res.data.id;
+    await cli(`places create ${payload}`);
   });
 
-  it('should return 200 for \'places list\'', async () => {
-    const res = await cli('places list');
+  it('should make correct request for \'places list\'', async () => {
+    mockApi()
+      .get('/places?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('places list');
   });
 
-  it('should return 200 for \'places $id read\'', async () => {
-    const res = await cli(`places ${ctx.placeId} read`);
+  it('should make correct request for \'places $id read\'', async () => {
+    mockApi()
+      .get(`/places/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`places ${ID} read`);
   });
 
-  it('should return 200 for \'places $id update $payload\'', async () => {
+  it('should make correct request for \'places $id update $payload\'', async () => {
     const payload = JSON.stringify({ tags: ['test'] });
-    const res = await cli(`places ${ctx.placeId} update ${payload}`);
+    mockApi()
+      .put(`/places/${ID}`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`places ${ID} update ${payload}`);
   });
 
-  it('should return 200 for \'places $id delete\'', async () => {
-    const res = await cli(`places ${ctx.placeId} delete`);
+  it('should make correct request for \'places $id delete\'', async () => {
+    mockApi()
+      .delete(`/places/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`places ${ID} delete`);
   });
 });

--- a/tests/commands/product.js
+++ b/tests/commands/product.js
@@ -3,151 +3,156 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
-const { ctx } = require('../util');
+const { ID, NAME, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
-const TEST_KEY = 'test';
-
 describe('products', () => {
-  before(async () => {
-    const payload = JSON.stringify({ name: `_action-type-${Date.now()}` });
-    const res = await cli(`action-types create ${payload}`);
-
-    ctx.actionType = res.data.name;
-  });
-
-  after(async () => {
-    await cli(`action-types ${ctx.actionType} delete`);
-  });
-
   // Product CRUD
-  it('should return 201 for \'products create $payload\'', async () => {
+  it('should make correct request for \'products create $payload\'', async () => {
     const payload = JSON.stringify({ name: 'Test product' });
-    const res = await cli(`products create ${payload}`);
+    mockApi()
+      .post('/products', payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.productId = res.data.id;
+    await cli(`products create ${payload}`);
   });
 
-  it('should return 200 for \'products list\'', async () => {
-    const res = await cli('products list');
+  it('should make correct request for \'products list\'', async () => {
+    mockApi()
+      .get('/products?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('products list');
   });
 
-  it('should return 200 for \'products $id read\'', async () => {
-    const res = await cli(`products ${ctx.productId} read`);
+  it('should make correct request for \'products $id read\'', async () => {
+    mockApi()
+      .get(`/products/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`products ${ID} read`);
   });
 
-  it('should return 200 for \'products $id update $payload\'', async () => {
+  it('should make correct request for \'products $id update $payload\'', async () => {
     const payload = JSON.stringify({ tags: ['test'] });
-    const res = await cli(`products ${ctx.productId} update ${payload}`);
+    mockApi()
+      .put(`/products/${ID}`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`products ${ID} update ${payload}`);
   });
 
   // Product properties
-  it('should return 200 for \'products $id properties create $payload\'', async () => {
-    const payload = JSON.stringify([{ key: TEST_KEY, value: 'some value' }]);
-    const res = await cli(`products ${ctx.productId} properties create ${payload}`);
+  it('should make correct request for \'products $id properties create $payload\'', async () => {
+    const payload = JSON.stringify([{ key: NAME, value: 'some value' }]);
+    mockApi()
+      .put(`/products/${ID}/properties`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`products ${ID} properties create ${payload}`);
   });
 
-  it('should return 200 for \'products $id properties list\'', async () => {
-    const res = await cli(`products ${ctx.productId} properties list`);
+  it('should make correct request for \'products $id properties list\'', async () => {
+    mockApi()
+      .get(`/products/${ID}/properties?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`products ${ID} properties list`);
   });
 
-  it('should return 200 for \'products $id properties $key read\'', async () => {
-    const res = await cli(`products ${ctx.productId} properties ${TEST_KEY} read`);
+  it('should make correct request for \'products $id properties $key read\'', async () => {
+    mockApi()
+      .get(`/products/${ID}/properties/${NAME}?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`products ${ID} properties ${NAME} read`);
   });
 
-  it('should return 200 for \'products $id properties $key update $payload\'', async () => {
-    const payload = JSON.stringify([{ value: 'some value' }]);
-    const res = await cli(`products ${ctx.productId} properties ${TEST_KEY} update ${payload}`);
+  it('should make correct request for \'products $id properties $key update $payload\'',
+    async () => {
+      const payload = JSON.stringify([{ value: 'some value' }]);
+      mockApi()
+        .put(`/products/${ID}/properties/${NAME}`, payload)
+        .reply(200);
 
-    expect(res.status).to.equal(200);
-  });
+      await cli(`products ${ID} properties ${NAME} update ${payload}`);
+    });
 
-  it('should return 200 for \'products $id properties $key delete\'', async () => {
-    const res = await cli(`products ${ctx.productId} properties ${TEST_KEY} delete`);
+  it('should make correct request for \'products $id properties $key delete\'', async () => {
+    mockApi()
+      .delete(`/products/${ID}/properties/${NAME}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`products ${ID} properties ${NAME} delete`);
   });
 
   // Product actions
-  it('should return 201 for \'products $id actions create $payload\'', async () => {
-    const payload = JSON.stringify({ type: ctx.actionType });
-    const res = await cli(`products ${ctx.productId} actions create ${payload}`);
+  it('should make correct request for \'products $id actions create $payload\'', async () => {
+    const payload = JSON.stringify({ type: NAME });
+    mockApi()
+      .post(`/products/${ID}/actions/all`, payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.actionId = res.data.id;
+    await cli(`products ${ID} actions create ${payload}`);
   });
 
-  it('should return 200 for \'products $id actions list\'', async () => {
-    const res = await cli(`products ${ctx.productId} actions list`);
+  it('should make correct request for \'products $id actions list\'', async () => {
+    mockApi()
+      .get(`/products/${ID}/actions/all?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`products ${ID} actions list`);
   });
 
-  it('should return 200 for \'products $id actions $id read\'', async () => {
-    const res = await cli(`products ${ctx.productId} actions ${ctx.actionId} read`);
+  it('should make correct request for \'products $id actions $id read\'', async () => {
+    mockApi()
+      .get(`/products/${ID}/actions/all/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`products ${ID} actions ${ID} read`);
   });
 
   // Product redirection
-  it('should return 201 for \'products $id redirection create $payload\'', async () => {
+  it('should make correct request for \'products $id redirection create $payload\'', async () => {
     const payload = JSON.stringify({ defaultRedirectUrl: 'https://google.com/{shortId}/' });
-    const res = await cli(`products ${ctx.productId} redirection create ${payload}`);
+    mockApi()
+      .post(`/products/${ID}/redirector`, payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
+    await cli(`products ${ID} redirection create ${payload}`);
   });
 
-  it('should return 200 for \'products $id redirection read\'', async () => {
-    const res = await cli(`products ${ctx.productId} redirection read`);
+  it('should make correct request for \'products $id redirection read\'', async () => {
+    mockApi()
+      .get(`/products/${ID}/redirector?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`products ${ID} redirection read`);
   });
 
-  it('should return 201 for \'products $id redirection update $payload\'', async () => {
+  it('should make correct request for \'products $id redirection update $payload\'', async () => {
     const payload = JSON.stringify({ defaultRedirectUrl: 'https://google.com/{shortId}/updates/' });
-    const res = await cli(`products ${ctx.productId} redirection update ${payload}`);
+    mockApi()
+      .put(`/products/${ID}/redirector`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`products ${ID} redirection update ${payload}`);
   });
 
-  it('should return 200 for \'products $id redirection delete\'', async () => {
-    const res = await cli(`products ${ctx.productId} redirection delete`);
+  it('should make correct request for \'products $id redirection delete\'', async () => {
+    mockApi()
+      .delete(`/products/${ID}/redirector`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`products ${ID} redirection delete`);
   });
 
   // Finally
-  it('should return 200 for \'products $id delete\'', async () => {
-    const res = await cli(`products ${ctx.productId} delete`);
+  it('should make correct request for \'products $id delete\'', async () => {
+    mockApi()
+      .delete(`/products/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`products ${ID} delete`);
   });
 });

--- a/tests/commands/project.js
+++ b/tests/commands/project.js
@@ -3,208 +3,222 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
-const { ctx } = require('../util');
+const { ID, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
 describe('projects', () => {
   // Project CRUD
-  it('should return 201 for \'projects create $payload\'', async () => {
+  it('should make correct request for \'projects create $payload\'', async () => {
     const payload = JSON.stringify({ name: 'Test project' });
-    const res = await cli(`projects create ${payload}`);
+    mockApi()
+      .post('/projects', payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.projectId = res.data.id;
+    await cli(`projects create ${payload}`);
   });
 
-  it('should return 200 for \'projects list\'', async () => {
-    const res = await cli('projects list');
+  it('should make correct request for \'projects list\'', async () => {
+    mockApi()
+      .get('/projects?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('projects list');
   });
 
-  it('should return 200 for \'projects $id read\'', async () => {
-    const res = await cli(`projects ${ctx.projectId} read`);
+  it('should make correct request for \'projects $id read\'', async () => {
+    mockApi()
+      .get(`/projects/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`projects ${ID} read`);
   });
 
-  it('should return 200 for \'projects $id update $payload\'', async () => {
+  it('should make correct request for \'projects $id update $payload\'', async () => {
     const payload = JSON.stringify({ tags: ['test'] });
-    const res = await cli(`projects ${ctx.projectId} update ${payload}`);
+    mockApi()
+      .put(`/projects/${ID}`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`projects ${ID} update ${payload}`);
   });
 
   // Applications CRUD
-  it('should return 200 for \'projects $id applications create $payload\'', async () => {
+  it('should make correct request for \'projects $id applications create $payload\'', async () => {
     const payload = JSON.stringify({ name: 'Test application', socialNetworks: {} });
-    const res = await cli(`projects ${ctx.projectId} applications create ${payload}`);
+    mockApi()
+      .post(`/projects/${ID}/applications`, payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.appId = res.data.id;
+    await cli(`projects ${ID} applications create ${payload}`);
   });
 
-  it('should return 200 for \'projects $id applications list\'', async () => {
-    const res = await cli(`projects ${ctx.projectId} applications list`);
+  it('should make correct request for \'projects $id applications list\'', async () => {
+    mockApi()
+      .get(`/projects/${ID}/applications?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`projects ${ID} applications list`);
   });
 
-  it('should return 200 for \'projects $id applications $id read\'', async () => {
-    const res = await cli(`projects ${ctx.projectId} applications ${ctx.appId} read`);
+  it('should make correct request for \'projects $id applications $id read\'', async () => {
+    mockApi()
+      .get(`/projects/${ID}/applications/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`projects ${ID} applications ${ID} read`);
   });
 
-  it('should return 200 for \'projects $id applications $id update $payload\'', async () => {
-    const payload = JSON.stringify({ description: 'Updated application' });
-    const res = await cli(`projects ${ctx.projectId} applications ${ctx.appId} update ${payload}`);
+  it('should make correct request for \'projects $id applications $id update $payload\'',
+    async () => {
+      const payload = JSON.stringify({ description: 'Updated application' });
+      mockApi()
+        .put(`/projects/${ID}/applications/${ID}`, payload)
+        .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
-  });
+      await cli(`projects ${ID} applications ${ID} update ${payload}`);
+    });
 
   // Trusted API Key
-  it('should return 200 for \'projects $id applications $id secret-key read\'', async () => {
-    const res = await cli(`projects ${ctx.projectId} applications ${ctx.appId} secret-key read`);
+  it('should make correct request for \'projects $id applications $id secret-key read\'',
+    async () => {
+      mockApi()
+        .get(`/projects/${ID}/applications/${ID}/secretKey?perPage=30`)
+        .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
-  });
+      await cli(`projects ${ID} applications ${ID} secret-key read`);
+    });
 
   // Application Redirector
-  it('should return 200 for \'projects $id applications $id redirector read\'', async () => {
-    const res = await cli(`projects ${ctx.projectId} applications ${ctx.appId} redirector read`);
+  it('should make correct request for \'projects $id applications $id redirector read\'',
+    async () => {
+      mockApi()
+        .get(`/projects/${ID}/applications/${ID}/redirector?perPage=30`,)
+        .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
-  });
+      await cli(`projects ${ID} applications ${ID} redirector read`);
+    });
 
-  it('should return 200 for \'projects $id applications $id redirector update $payload\'',
+  it('should make correct request for \'projects $id applications $id redirector update $payload\'',
     async () => {
       const payload = JSON.stringify({
         rules: [{ match: 'thng.name=test', redirectUrl: 'https://evrythng.com' }],
       });
-      const argStr = `projects ${ctx.projectId} applications ${ctx.appId} redirector update ${payload}`;
-      const res = await cli(argStr);
+      mockApi()
+        .put(`/projects/${ID}/applications/${ID}/redirector`, payload)
+        .reply(200);
 
-      expect(res.status).to.equal(200);
-      expect(res.data).to.be.an('object');
+      await cli(`projects ${ID} applications ${ID} redirector update ${payload}`);
     });
 
   // Application Reactor
-  it('should return 200 for \'projects $id applications $id reactor script read\'', async () => {
-    const argStr = `projects ${ctx.projectId} applications ${ctx.appId} reactor script read`;
-    const res = await cli(argStr);
-
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
-  });
-
-  it('should return 200 for \'projects $id applications $id reactor script update $payload\'',
+  it('should make correct request for \'projects $id applications $id reactor script read\'',
     async () => {
-      const payload = JSON.stringify({
-        script: 'function onActionCreated(event) {\n logger.debug(\'Hello World!\');\n done();}',
-      });
-      const argStr = `projects ${ctx.projectId} applications ${ctx.appId} reactor script update ${payload}`;
-      const res = await cli(argStr);
+      mockApi()
+        .get(`/projects/${ID}/applications/${ID}/reactor/script?perPage=30`)
+        .reply(200);
 
-      expect(res.status).to.equal(200);
-      expect(res.data).to.be.an('object');
+      await cli(`projects ${ID} applications ${ID} reactor script read`);
     });
 
-  it('should return 200 for \'projects $id applications $id reactor script status read\'',
+  it('should make correct request for \'projects $id applications $id reactor script update $payload\'',
     async () => {
-      const argStr = `projects ${ctx.projectId} applications ${ctx.appId} reactor script status read`;
-      const res = await cli(argStr);
+      const script = 'function onActionCreated(event) {\n logger.debug(\'Hello World!\');\n done();}';
+      const payload = JSON.stringify({ script });
+      mockApi()
+        .put(`/projects/${ID}/applications/${ID}/reactor/script`, payload)
+        .reply(200);
 
-      expect(res.status).to.equal(200);
-      expect(res.data).to.be.an('object');
+      await cli(`projects ${ID} applications ${ID} reactor script update ${payload}`);
     });
 
-  it('should return 200 for \'projects $id applications $id reactor logs read\'', async () => {
-    const argStr = `projects ${ctx.projectId} applications ${ctx.appId} reactor logs read`;
-    const res = await cli(argStr);
+  it('should make correct request for \'projects $id applications $id reactor script status read\'',
+    async () => {
+      mockApi()
+        .get(`/projects/${ID}/applications/${ID}/reactor/script/status?perPage=30`)
+        .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
-  });
+      await cli(`projects ${ID} applications ${ID} reactor script status read`);
+    });
 
-  it('should return 200 for \'projects $id applications $id reactor logs delete\'', async () => {
-    const argStr = `projects ${ctx.projectId} applications ${ctx.appId} reactor logs delete`;
-    const res = await cli(argStr);
+  it('should make correct request for \'projects $id applications $id reactor logs read\'',
+    async () => {
+      mockApi()
+        .get(`/projects/${ID}/applications/${ID}/reactor/logs?perPage=30`)
+        .reply(200);
 
-    expect(res.status).to.equal(200);
-  });
+      await cli(`projects ${ID} applications ${ID} reactor logs read`);
+    });
 
-  it('should return 201 for \'projects $id applications $id reactor schedules create $payload\'',
+  it('should make correct request for \'projects $id applications $id reactor logs delete\'',
+    async () => {
+      mockApi()
+        .delete(`/projects/${ID}/applications/${ID}/reactor/logs`)
+        .reply(200);
+
+      await cli(`projects ${ID} applications ${ID} reactor logs delete`);
+    });
+
+  it('should make correct request for \'projects $id applications $id reactor schedules create $payload\'',
     async () => {
       const payload = JSON.stringify({ event: {}, executeAt: Date.now() + 60000 });
-      const argStr = `projects ${ctx.projectId} applications ${ctx.appId} reactor schedules create ${payload}`;
-      const res = await cli(argStr);
+      mockApi()
+        .post(`/projects/${ID}/applications/${ID}/reactor/schedules`, payload)
+        .reply(201);
 
-      expect(res.status).to.equal(201);
-      expect(res.data).to.be.an('object');
-
-      ctx.scheduleId = res.data.id;
+      await cli(`projects ${ID} applications ${ID} reactor schedules create ${payload}`);
     });
 
-  it('should return 200 for \'projects $id applications $id reactor schedules list\'', async () => {
-    const argStr = `projects ${ctx.projectId} applications ${ctx.appId} reactor schedules list`;
-    const res = await cli(argStr);
-
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
-  });
-
-  it('should return 200 for \'projects $id applications $id reactor schedules $id read\'',
+  it('should make correct request for \'projects $id applications $id reactor schedules list\'',
     async () => {
-      const argStr = `projects ${ctx.projectId} applications ${ctx.appId} reactor schedules ${ctx.scheduleId} read`;
-      const res = await cli(argStr);
+      mockApi()
+        .get(`/projects/${ID}/applications/${ID}/reactor/schedules?perPage=30`)
+        .reply(200);
 
-      expect(res.status).to.equal(200);
-      expect(res.data).to.be.an('object');
+      await cli(`projects ${ID} applications ${ID} reactor schedules list`);
     });
 
-  it(
-    'should return 200 for \'projects $id applications $id reactor schedules $id update $payload\'',
+  it('should make correct request for \'projects $id applications $id reactor schedules $id read\'',
+    async () => {
+      mockApi()
+        .get(`/projects/${ID}/applications/${ID}/reactor/schedules/${ID}`)
+        .reply(200);
+
+      await cli(`projects ${ID} applications ${ID} reactor schedules ${ID} read`);
+    });
+
+  it('should make correct request for \'projects $id applications $id reactor schedules $id update $payload\'',
     async () => {
       const payload = JSON.stringify({ description: 'Updated schedule' });
-      const argStr = `projects ${ctx.projectId} applications ${ctx.appId} reactor schedules ${ctx.scheduleId} update ${payload}`;
-      const res = await cli(argStr);
+      mockApi()
+        .put(`/projects/${ID}/applications/${ID}/reactor/schedules/${ID}`, payload)
+        .reply(200);
 
-      expect(res.status).to.equal(200);
-      expect(res.data).to.be.an('object');
+      await cli(`projects ${ID} applications ${ID} reactor schedules ${ID} update ${payload}`);
     });
 
-  it('should return 200 for \'projects $id applications $id reactor schedules $id delete\'',
+  it('should make correct request for \'projects $id applications $id reactor schedules $id delete\'',
     async () => {
-      const argStr = `projects ${ctx.projectId} applications ${ctx.appId} reactor schedules ${ctx.scheduleId} delete`;
-      const res = await cli(argStr);
+      mockApi()
+        .delete(`/projects/${ID}/applications/${ID}/reactor/schedules/${ID}`)
+        .reply(200);
 
-      expect(res.status).to.equal(200);
+      await cli(`projects ${ID} applications ${ID} reactor schedules ${ID} delete`);
     });
 
   // Finally
-  it('should return 200 for \'projects $id applications $id delete\'', async () => {
-    const res = await cli(`projects ${ctx.projectId} applications ${ctx.appId} delete`);
+  it('should make correct request for \'projects $id applications $id delete\'', async () => {
+    mockApi()
+      .delete(`/projects/${ID}/applications/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`projects ${ID} applications ${ID} delete`);
   });
 
-  it('should return 200 for \'projects $id delete\'', async () => {
-    const res = await cli(`projects ${ctx.projectId} delete`);
+  it('should make correct request for \'projects $id delete\'', async () => {
+    mockApi()
+      .delete(`/projects/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`projects ${ID} delete`);
   });
 });

--- a/tests/commands/rateLimit.js
+++ b/tests/commands/rateLimit.js
@@ -3,14 +3,15 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
+const { mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
 describe('rate-limits', () => {
-  it('should return 200 for \'rate-limits read\'', async () => {
-    const res = await cli(`rate-limits read`);
+  it('should make correct request for \'rate-limits read\'', async () => {
+    mockApi()
+      .get('/rateLimits?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`rate-limits read`);
   });
 });

--- a/tests/commands/redirector.js
+++ b/tests/commands/redirector.js
@@ -3,24 +3,26 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
+const { mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
 describe('redirector', () => {
-  it('should return 200 for \'redirector read\'', async () => {
-    const res = await cli(`redirector read`);
+  it('should make correct request for \'redirector read\'', async () => {
+    mockApi()
+      .get('/redirector?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`redirector read`);
   });
 
-  it('should return 200 for \'redirector update $payload\'', async () => {
+  it('should make correct request for \'redirector update $payload\'', async () => {
     const payload = JSON.stringify({
       rules: [{ match: 'thng.name=test', delegates: [] }],
     });
-    const res = await cli(`redirector update ${payload}`);
+    mockApi()
+      .put('/redirector', payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`redirector update ${payload}`);
   });
 });

--- a/tests/commands/role.js
+++ b/tests/commands/role.js
@@ -3,68 +3,73 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
-const { ctx } = require('../util');
+const { ID, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
 describe('roles', () => {
   // Role CRUD
-  it('should return 201 for \'roles create $payload\'', async () => {
+  it('should make correct request for \'roles create $payload\'', async () => {
     const payload = JSON.stringify({
       name: 'Test role',
       version: 2,
       type: 'userInApp',
     });
-    const res = await cli(`roles create ${payload}`);
+    mockApi()
+      .post('/roles', payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.roleId = res.data.id;
+    await cli(`roles create ${payload}`);
   });
 
-  it('should return 200 for \'roles list\'', async () => {
-    const res = await cli('roles list');
+  it('should make correct request for \'roles list\'', async () => {
+    mockApi()
+      .get('/roles?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('roles list');
   });
 
-  it('should return 200 for \'roles $id read\'', async () => {
-    const res = await cli(`roles ${ctx.roleId} read`);
+  it('should make correct request for \'roles $id read\'', async () => {
+    mockApi()
+      .get(`/roles/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`roles ${ID} read`);
   });
 
-  it('should return 200 for \'roles $id update $payload\'', async () => {
+  it('should make correct request for \'roles $id update $payload\'', async () => {
     const payload = JSON.stringify({ customFields: { key: 'value' } });
-    const res = await cli(`roles ${ctx.roleId} update ${payload}`);
+    mockApi()
+      .put(`/roles/${ID}`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`roles ${ID} update ${payload}`);
   });
 
   // Role Permissions
-  it('should return 200 for \'roles $id permissions list\'', async () => {
-    const res = await cli(`roles ${ctx.roleId} permissions list`);
+  it('should make correct request for \'roles $id permissions list\'', async () => {
+    mockApi()
+      .get(`/roles/${ID}/permissions?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`roles ${ID} permissions list`);
   });
 
-  it('should return 200 for \'roles $id permissions update $payload\'', async () => {
+  it('should make correct request for \'roles $id permissions update $payload\'', async () => {
     const payload = JSON.stringify([{ path: '/thngs', access: 'r' }]);
-    const res = await cli(`roles ${ctx.roleId} permissions update ${payload}`);
+    mockApi()
+      .put(`/roles/${ID}/permissions`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`roles ${ID} permissions update ${payload}`);
   });
 
   // Finally
-  it('should return 200 for \'roles $id delete\'', async () => {
-    const res = await cli(`roles ${ctx.roleId} delete`);
+  it('should make correct request for \'roles $id delete\'', async () => {
+    mockApi()
+      .delete(`/roles/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`roles ${ID} delete`);
   });
 });

--- a/tests/commands/thng.js
+++ b/tests/commands/thng.js
@@ -3,199 +3,210 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
-const { ctx } = require('../util');
+const { ID, NAME, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
-const TEST_KEY = 'test';
-
 describe('thngs', () => {
-  before(async () => {
-    const payload = JSON.stringify({ name: `_action-type-${Date.now()}` });
-    const res = await cli(`action-types create ${payload}`);
-
-    ctx.actionType = res.data.name;
-  });
-
-  after(async () => {
-    await cli(`action-types ${ctx.actionType} delete`);
-  });
-
   // Thng CRUD
-  it('should return 201 for \'thngs create $payload\'', async () => {
+  it('should make correct request for \'thngs create $payload\'', async () => {
     const payload = JSON.stringify({ name: 'Test thng' });
-    const res = await cli(`thngs create ${payload}`);
+    mockApi()
+      .post('/thngs', payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.thngId = res.data.id;
+    await cli(`thngs create ${payload}`);
   });
 
-  it('should return 200 for \'thngs list\'', async () => {
-    const res = await cli('thngs list');
+  it('should make correct request for \'thngs list\'', async () => {
+    mockApi()
+      .get('/thngs?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('thngs list');
   });
 
-  it('should return 200 for \'thngs $id read\'', async () => {
-    const res = await cli(`thngs ${ctx.thngId} read`);
+  it('should make correct request for \'thngs $id read\'', async () => {
+    mockApi()
+      .get(`/thngs/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`thngs ${ID} read`);
   });
 
-  it('should return 200 for \'thngs $id update $payload\'', async () => {
+  it('should make correct request for \'thngs $id update $payload\'', async () => {
     const payload = JSON.stringify({ tags: ['test'] });
-    const res = await cli(`thngs ${ctx.thngId} update ${payload}`);
+    mockApi()
+      .put(`/thngs/${ID}`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`thngs ${ID} update ${payload}`);
   });
 
   // Thng properties
-  it('should return 200 for \'thngs $id properties create $payload\'', async () => {
-    const payload = JSON.stringify([{ key: TEST_KEY, value: 'some value' }]);
-    const res = await cli(`thngs ${ctx.thngId} properties create ${payload}`);
+  it('should make correct request for \'thngs $id properties create $payload\'', async () => {
+    const payload = JSON.stringify([{ key: NAME, value: 'some value' }]);
+    mockApi()
+      .put(`/thngs/${ID}/properties`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`thngs ${ID} properties create ${payload}`);
   });
 
-  it('should return 200 for \'thngs $id properties list\'', async () => {
-    const res = await cli(`thngs ${ctx.thngId} properties list`);
+  it('should make correct request for \'thngs $id properties list\'', async () => {
+    mockApi()
+      .get(`/thngs/${ID}/properties?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`thngs ${ID} properties list`);
   });
 
-  it('should return 200 for \'thngs $id properties $key read\'', async () => {
-    const res = await cli(`thngs ${ctx.thngId} properties ${TEST_KEY} read`);
+  it('should make correct request for \'thngs $id properties $key read\'', async () => {
+    mockApi()
+      .get(`/thngs/${ID}/properties/${NAME}?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`thngs ${ID} properties ${NAME} read`);
   });
 
-  it('should return 200 for \'thngs $id properties $key update $payload\'', async () => {
+  it('should make correct request for \'thngs $id properties $key update $payload\'', async () => {
     const payload = JSON.stringify([{ value: 'some value' }]);
-    const res = await cli(`thngs ${ctx.thngId} properties ${TEST_KEY} update ${payload}`);
+    mockApi()
+      .put(`/thngs/${ID}/properties/${NAME}`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`thngs ${ID} properties ${NAME} update ${payload}`);
   });
 
-  it('should return 200 for \'thngs $id properties $key delete\'', async () => {
-    const res = await cli(`thngs ${ctx.thngId} properties ${TEST_KEY} delete`);
+  it('should make correct request for \'thngs $id properties $key delete\'', async () => {
+    mockApi()
+      .delete(`/thngs/${ID}/properties/${NAME}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`thngs ${ID} properties ${NAME} delete`);
   });
 
   // Thng actions
-  it('should return 201 for \'thngs $id actions create $payload\'', async () => {
-    const payload = JSON.stringify({ type: ctx.actionType });
-    const res = await cli(`thngs ${ctx.thngId} actions create ${payload}`);
+  it('should make correct request for \'thngs $id actions create $payload\'', async () => {
+    const payload = JSON.stringify({ type: NAME });
+    mockApi()
+      .post(`/thngs/${ID}/actions/all`, payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.actionId = res.data.id;
+    await cli(`thngs ${ID} actions create ${payload}`);
   });
 
-  it('should return 200 for \'thngs $id actions list\'', async () => {
-    const res = await cli(`thngs ${ctx.thngId} actions list`);
+  it('should make correct request for \'thngs $id actions list\'', async () => {
+    mockApi()
+      .get(`/thngs/${ID}/actions/all?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`thngs ${ID} actions list`);
   });
 
-  it('should return 200 for \'thngs $id actions $id read\'', async () => {
-    const res = await cli(`thngs ${ctx.thngId} actions ${ctx.actionId} read`);
+  it('should make correct request for \'thngs $id actions $id read\'', async () => {
+    mockApi()
+      .get(`/thngs/${ID}/actions/all/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`thngs ${ID} actions ${ID} read`);
   });
 
   // Thng redirection
-  it('should return 201 for \'thngs $id redirection create $payload\'', async () => {
+  it('should make correct request for \'thngs $id redirection create $payload\'', async () => {
     const payload = JSON.stringify({ defaultRedirectUrl: 'https://google.com/{shortId}/' });
-    const res = await cli(`thngs ${ctx.thngId} redirection create ${payload}`);
+    mockApi()
+      .post(`/thngs/${ID}/redirector`, payload)
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
+    await cli(`thngs ${ID} redirection create ${payload}`);
   });
 
-  it('should return 200 for \'thngs $id redirection read\'', async () => {
-    const res = await cli(`thngs ${ctx.thngId} redirection read`);
+  it('should make correct request for \'thngs $id redirection read\'', async () => {
+    mockApi()
+      .get(`/thngs/${ID}/redirector?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`thngs ${ID} redirection read`);
   });
 
-  it('should return 201 for \'thngs $id redirection update $payload\'', async () => {
+  it('should make correct request for \'thngs $id redirection update $payload\'', async () => {
     const payload = JSON.stringify({ defaultRedirectUrl: 'https://google.com/{shortId}/updates/' });
-    const res = await cli(`thngs ${ctx.thngId} redirection update ${payload}`);
+    mockApi()
+      .put(`/thngs/${ID}/redirector`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`thngs ${ID} redirection update ${payload}`);
   });
 
-  it('should return 200 for \'thngs $id redirection delete\'', async () => {
-    const res = await cli(`thngs ${ctx.thngId} redirection delete`);
+  it('should make correct request for \'thngs $id redirection delete\'', async () => {
+    mockApi()
+      .delete(`/thngs/${ID}/redirector`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`thngs ${ID} redirection delete`);
   });
 
   // Thng location
-  it('should return 200 for \'thngs $id location read\'', async () => {
-    const res = await cli(`thngs ${ctx.thngId} location read`);
+  it('should make correct request for \'thngs $id location read\'', async () => {
+    mockApi()
+      .get(`/thngs/${ID}/location?perPage=30`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`thngs ${ID} location read`);
   });
 
-  it('should return 200 for \'thngs $id location update $payload\'', async () => {
+  it('should make correct request for \'thngs $id location update $payload\'', async () => {
     const payload = JSON.stringify([{
       position: { type: 'Point', coordinates: [ -17.3, 36 ] },
     }]);
-    const res = await cli(`thngs ${ctx.thngId} location update ${payload}`);
+    mockApi()
+      .put(`/thngs/${ID}/location`, payload)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`thngs ${ID} location update ${payload}`);
   });
 
-  it('should return 200 for \'thngs $id location delete\'', async () => {
-    const res = await cli(`thngs ${ctx.thngId} location delete`);
+  it('should make correct request for \'thngs $id location delete\'', async () => {
+    mockApi()
+      .delete(`/thngs/${ID}/location`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`thngs ${ID} location delete`);
   });
 
   // Thng Device API Key
-  it('should return 201 for \'thngs device-key create $payload\'', async () => {
-    const payload = JSON.stringify({ thngId: ctx.thngId });
-    const res = await cli(`thngs device-key create ${payload}`);
+  it('should make correct request for \'thngs device-key create $payload\'', async () => {
+    const payload = JSON.stringify({ thngId: ID });
+    mockApi()
+      .post('/auth/evrythng/thngs')
+      .reply(201);
 
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
+    await cli(`thngs device-key create ${payload}`);
   });
 
-  it('should return 200 for \'thngs $id device-key read\'', async () => {
-    const payload = JSON.stringify({ thngId: ctx.thngId });
-    const res = await cli(`thngs ${ctx.thngId} device-key read`);
+  it('should make correct request for \'thngs $id device-key read\'', async () => {
+    const payload = JSON.stringify({ thngId: ID });
+    mockApi()
+      .get(`/auth/evrythng/thngs/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    await cli(`thngs ${ID} device-key read`);
   });
 
-  it('should return 200 for \'thngs $id device-key delete\'', async () => {
-    const payload = JSON.stringify({ thngId: ctx.thngId });
-    const res = await cli(`thngs ${ctx.thngId} device-key delete`);
+  it('should make correct request for \'thngs $id device-key delete\'', async () => {
+    mockApi()
+      .delete(`/auth/evrythng/thngs/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`thngs ${ID} device-key delete`);
   });
 
   // Finally
-  it('should return 200 for \'thngs $id delete\'', async () => {
-    const res = await cli(`thngs ${ctx.thngId} delete`);
+  it('should make correct request for \'thngs $id delete\'', async () => {
+    mockApi()
+      .delete(`/thngs/${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
+    await cli(`thngs ${ID} delete`);
   });
 });

--- a/tests/commands/url.js
+++ b/tests/commands/url.js
@@ -3,39 +3,41 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const { expect } = require('chai');
-const { ctx } = require('../util');
+const { ID, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
 describe('url', () => {
-  it('should return 201 for \'url post $url $payload\'', async () => {
+  it('should make correct request for \'url post $url $payload\'', async () => {
     const payload = JSON.stringify({ name: 'Test Thng' });
-    const res = await cli(`url post /thngs ${payload}`);
-
-    expect(res.status).to.equal(201);
-    expect(res.data).to.be.an('object');
-
-    ctx.thngId = res.data.id;
+    mockApi()
+      .post('/thngs', payload)
+      .reply(201);
+    
+    await cli(`url post /thngs ${payload}`);
   });
 
-  it('should return 200 for \'url get $url\'', async () => {
-    const res = await cli('url get /thngs');
-
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+  it('should make correct request for \'url get $url\'', async () => {
+    mockApi()
+      .get('/thngs?perPage=30')
+      .reply(200);
+    
+    await cli('url get /thngs');
   });
 
-  it('should return 200 for \'url put $url $payload\'', async () => {
+  it('should make correct request for \'url put $url $payload\'', async () => {
     const payload = JSON.stringify({ name: 'Updated Thng' });
-    const res = await cli(`url put /thngs/${ctx.thngId} ${payload}`);
-
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('object');
+    mockApi()
+      .put(`/thngs/${ID}`, payload)
+      .reply(200);
+    
+    await cli(`url put /thngs/${ID} ${payload}`);
   });
 
-  it('should return 200 for \'url delete $url\'', async () => {
-    const res = await cli(`url delete /thngs/${ctx.thngId}`);
-
-    expect(res.status).to.equal(200);
+  it('should make correct request for \'url delete $url\'', async () => {
+    mockApi()
+      .delete(`/thngs/${ID}`)
+      .reply(200);
+    
+    await cli(`url delete /thngs/${ID}`);
   });
 });

--- a/tests/main.js
+++ b/tests/main.js
@@ -5,6 +5,7 @@
 
 const { expect } = require('chai');
 const { ctx } = require('./util');
+const sinon = require('sinon');
 const cli = require('../src/functions/cli');
 const config = require('../src/modules/config');
 const expand = require('../src/functions/expand');
@@ -27,6 +28,10 @@ describe('CLI', () => {
 
   after(async () => {
     config.set('options', ctx.savedOpts);
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   require('./commands/access');

--- a/tests/modules/api.js
+++ b/tests/modules/api.js
@@ -4,6 +4,7 @@
  */
 
 const { expect } = require('chai');
+const { NAME, mockApi } = require('../util');
 const api = require('../../src/modules/api');
 const cli = require('../../src/functions/cli');
 const commands = require('../../src/modules/commands');
@@ -61,5 +62,13 @@ describe('api', () => {
     const switches = api.API.getSwitches();
 
     expect(switches).to.be.an('object');
+  });
+
+  it('should allow a command to be run', async () => {
+    mockApi()
+      .get('/products?perPage=30')
+      .reply(200, [{ name: NAME }]);
+
+    await api.API.runCommand(['products', 'list']);
   });
 });

--- a/tests/modules/csv.js
+++ b/tests/modules/csv.js
@@ -8,6 +8,7 @@ const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const fs = require('fs');
 const neatCsv = require('neat-csv');
+const { mockApi } = require('../util');
 const config = require('../../src/modules/config');
 const csv = require('../../src/modules/csv');
 const switches = require('../../src/modules/switches');
@@ -158,8 +159,14 @@ describe('csv', () => {
   });
 
   it('should not throw when reading from a CSV file', async () => {
+    const mock = mockApi()
+      .persist()
+      .post('/thngs?')
+      .reply(201, {});
+
     switches.FROM_CSV = CSV_PATH;
     await csv.read('thng');
+    mock.persist(false);
   });
 
   it('should escape commas and double quotes', () => {

--- a/tests/modules/switches.js
+++ b/tests/modules/switches.js
@@ -6,7 +6,7 @@
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const fs = require('fs');
-const { ctx } = require('../util');
+const { ID, API_KEY, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 const operator = require('../../src/commands/operator');
 const switches = require('../../src/modules/switches');
@@ -17,112 +17,119 @@ chai.use(chaiAsPromised);
 const CSV_PATH = './test.csv';
 
 describe('switches', () => {
-  after(async () => {
-    fs.unlinkSync(CSV_PATH);
-  });
-
   it('should accept the --filter switch', async () => {
-    const res = await cli('thngs list --filter tags=test');
-    switches.FILTER = false;
+    mockApi()
+      .get('/thngs?filter=tags%3Dtest&perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('thngs list --filter tags=test');
+    switches.FILTER = false;
   });
 
   it('should accept the --with-scopes switch', async () => {
-    const res = await cli('thngs list --with-scopes');
-    switches.SCOPES = false;
+    mockApi()
+      .get('/thngs?perPage=30&withScopes=true')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('thngs list --with-scopes');
+    switches.SCOPES = false;
   });
 
   it('should accept the --per-page switch', async () => {
-    const res = await cli('thngs list --per-page 1');
-    switches.PER_PAGE = false;
+    mockApi()
+      .get('/thngs?perPage=1')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
-    expect(res.data).to.have.length(1);
+    await cli('thngs list --per-page 1');
+    switches.PER_PAGE = false;
   });
 
   it('should accept the --summary switch', async () => {
-    const res = await cli('thngs list --summary');
-    switches.SUMMARY = false;
+    mockApi()
+      .get('/thngs?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('thngs list --summary');
+    switches.SUMMARY = false;
   });
 
   it('should accept the --api-key switch', async () => {
-    const res = await cli(`thngs list --api-key ${operator.getKey()}`);
-    switches.API_KEY = false;
+    mockApi()
+      .matchHeader('authorization', API_KEY)
+      .get('/thngs?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`thngs list --api-key ${API_KEY}`);
+    switches.API_KEY = false;
   });
 
   it('should accept the --expand switch', async () => {
-    const res = await cli('products list --expand');
-    switches.EXPAND = false;
+    mockApi()
+      .get('/products?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('products list --expand');
+    switches.EXPAND = false;
   });
 
   it('should accept the --field switch', async () => {
-    const res = await cli('access read --field account');
-    switches.FIELD = false;
+    mockApi()
+      .get('/access?perPage=30')
+      .reply(200);
 
-    expect(res).to.be.a('string');
+    await cli('access read --field account');
+    switches.FIELD = false;
   });
 
   it('should accept the --simple switch', async () => {
-    const res = await cli('thngs list --simple');
-    switches.SIMPLE = false;
+    mockApi()
+      .get('/thngs?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('thngs list --simple');
+    switches.SIMPLE = false;
   });
 
   it('should accept the --project switch', async () => {
-    let res = await cli('projects list');
-    res = await cli(`thngs list --project ${res.data[0].id}`);
-    switches.PROJECT = false;
+    mockApi()
+      .get(`/thngs?perPage=30&project=${ID}`)
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli(`thngs list --project ${ID}`);
+    switches.PROJECT = false;
   });
 
   it('should accept the --page switch', async () => {
-    const res = await cli('thngs list --page 1');
-    switches.PAGE = false;
+    mockApi()
+      .get('/thngs?perPage=30')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('thngs list --page 1');
+    switches.PAGE = false;
   });
 
   it('should accept the --context switch', async () => {
-    const res = await cli('actions scans list --context');
-    switches.CONTEXT = false;
+    mockApi()
+      .get('/actions/scans?perPage=30&context=true')
+      .reply(200);
 
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
+    await cli('actions scans list --context');
+    switches.CONTEXT = false;
   });
 
   it('should reject if --to-page is used without --to-csv', async () => {
-    const list = cli('thngs list --to-page 5');
-
-    return expect(list).to.be.rejectedWith(Error);  
+    const list = cli('thngs list --to-page 2');
+    return expect(list).to.eventually.be.rejected;
   });
 
   it('should accept the --to-page switch with --to-csv', async () => {
-    const res = await cli(`thngs list --to-page 5 --to-csv ${CSV_PATH}`);
+    mockApi()
+      .get('/thngs?perPage=30')
+      .reply(200);
+    
+    await cli(`thngs list --to-page 2 --to-csv ${CSV_PATH}`);
     switches.TO_PAGE = false;
     switches.TO_CSV = false;
-
-    expect(res.status).to.equal(200);
-    expect(res.data).to.be.an('array');
   });
 
   it('should accept the --build switch');

--- a/tests/util.js
+++ b/tests/util.js
@@ -3,10 +3,25 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
+const _  = require('lodash');
+const sinon = require('sinon');
+const nock = require('nock');
+const config = require('../src/modules/config');
 const cli = require('../src/functions/cli');
+const http = require('../src/modules/http');
+const operator = require('../src/commands/operator');
 const switches = require('../src/modules/switches');
 
 const ctx = {};
+
+/** Fake ID */
+const ID = '012345678901234567890123';
+
+/** Fake API key */
+const API_KEY = '01234567890123456789012345678901234567890123456789012345678901234567890123456789';
+
+/** Fake name for action types, property keys, etc. */
+const NAME = 'scans';
 
 const waitAsync = async ms => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -42,10 +57,59 @@ const createAppUser = async (name) => {
   return res.data;
 };
 
+/**
+ * Validate a CLI command string produces an API request. Quicker than an E2E test.
+ *
+ * @param {String} argStr - The CLI command, such as 'thngs list'.
+ * @param {Object} spec - The expected options produced by sendRequest.
+ * @param {String} apiKey - API key to use as the authorization header value, if not the Operator.
+ * @returns {Promise} A Promise that resolves when Sinon hears the call from http.js
+ */
+const validateRequest = (argStr, spec, apiKey) => new Promise((resolve, reject) => {
+  apiKey = apiKey || operator.getKey();
+
+  // Add extra fields not required for the test spec
+  Object.assign(spec, {
+    fullResponse: true,
+    authorization: apiKey,
+    displayHeaders: { Authorization: `${apiKey.slice(0, 4)}...` },
+  });
+
+  // Add listener for options produced by CLI command
+  sinon.stub(http, 'sendRequest').callsFake((options) => {
+    if (!_.isEqual(options, spec)) {
+      reject(`Options did not match spec: ${JSON.stringify(options)}`);
+      return;
+    }
+
+    resolve();
+  });
+
+  // Invoke the command for Sinon to listen for
+  cli(argStr);
+});
+
+/**
+ * Prepare nock for an API request.
+ *
+ * @param {boolean} allowUnmocked - Allow nock to make unmocked requests to the API.
+ * @returns {Object} nock scope object.
+ */
+const mockApi = (allowUnmocked = false) => {
+  const regions = config.get('regions');
+  const { region } = config.get('operators')[config.get('using')];
+  return nock(regions[region], { allowUnmocked });
+};
+
 module.exports = {
   ctx,
   waitAsync,
   createAppUser,
   createProject,
   createApplication,
+  validateRequest,
+  mockApi,
+  ID,
+  API_KEY,
+  NAME,
 };

--- a/tests/util.js
+++ b/tests/util.js
@@ -58,38 +58,6 @@ const createAppUser = async (name) => {
 };
 
 /**
- * Validate a CLI command string produces an API request. Quicker than an E2E test.
- *
- * @param {String} argStr - The CLI command, such as 'thngs list'.
- * @param {Object} spec - The expected options produced by sendRequest.
- * @param {String} apiKey - API key to use as the authorization header value, if not the Operator.
- * @returns {Promise} A Promise that resolves when Sinon hears the call from http.js
- */
-const validateRequest = (argStr, spec, apiKey) => new Promise((resolve, reject) => {
-  apiKey = apiKey || operator.getKey();
-
-  // Add extra fields not required for the test spec
-  Object.assign(spec, {
-    fullResponse: true,
-    authorization: apiKey,
-    displayHeaders: { Authorization: `${apiKey.slice(0, 4)}...` },
-  });
-
-  // Add listener for options produced by CLI command
-  sinon.stub(http, 'sendRequest').callsFake((options) => {
-    if (!_.isEqual(options, spec)) {
-      reject(`Options did not match spec: ${JSON.stringify(options)}`);
-      return;
-    }
-
-    resolve();
-  });
-
-  // Invoke the command for Sinon to listen for
-  cli(argStr);
-});
-
-/**
  * Prepare nock for an API request.
  *
  * @param {boolean} allowUnmocked - Allow nock to make unmocked requests to the API.
@@ -107,7 +75,6 @@ module.exports = {
   createAppUser,
   createProject,
   createApplication,
-  validateRequest,
   mockApi,
   ID,
   API_KEY,


### PR DESCRIPTION
_Fixes_
- Don't append `perPage` when the request is not a 'list request'.

_Misc_
- Use `nock` to mock API requests to enable faster testing, and remove dependencies on an external API.