### PR TITLE
Accept a known operator name with --api-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ Authentication is provided in two ways.
    Any request that can be done as an Operator is done with the currently 
    selected Operator.
 
-2. Using the `--api-key` switch to either override the current operator, or 
-   provide a separately required key (such as the Application API Key when 
-   creating Application Users).
+2. Using the `--api-key` switch to either override the currently selected
+   operator's API key, or provide a required key (such as the Application API
+   Key when creating Application Users). An existing operator's name is also
+   accepted.
 
 > You must add at least one Operator before you can begin using the CLI.
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Authentication is provided in two ways.
 
 2. Using the `--api-key` switch to either override the currently selected
    operator's API key, or provide a required key (such as the Application API
-   Key when creating Application Users). An existing operator's name is also
-   accepted.
+   Key when creating Application Users). An existing operator's name chosen
+   when using `operators add` is also accepted.
 
 > You must add at least one Operator before you can begin using the CLI.
 

--- a/src/commands/operator.js
+++ b/src/commands/operator.js
@@ -120,7 +120,7 @@ const addOperator = async (args) => {
  */
 const removeOperator = (args) => {
   const [name] = args;
-  
+
   const operators = config.get('operators');
   delete operators[name];
   config.set('operators', operators);
@@ -174,7 +174,20 @@ const getCurrent = () => config.get('operators')[config.get('using')];
 // ------------------------------------ API ------------------------------------
 
 const getKey = () => {
-  const override = switches.API_KEY;
+  let override = switches.API_KEY;
+  if (override) {
+    // API key or operator name?
+    const operators = config.get('operators');
+    if (operators[override]) {
+      // Apply operator as override
+      const { apiKey, region } = operators[override];
+      override = apiKey;
+      evrythng.setup({ apiUrl: REGIONS[region] });
+    } else if (override.length !== 80) {
+      // It's not a valid API key either
+      throw new Error('Invalid API key provided to --api-key');
+    }
+  }
 
   const operator = config.get('using');
   if (!operator) {

--- a/src/commands/operator.js
+++ b/src/commands/operator.js
@@ -176,8 +176,9 @@ const getCurrent = () => config.get('operators')[config.get('using')];
 const getKey = () => {
   let override = switches.API_KEY;
   if (override) {
-    // API key or operator name?
     const operators = config.get('operators');
+
+    // API key or operator name?
     if (operators[override]) {
       // Apply operator as override
       const { apiKey, region } = operators[override];

--- a/src/modules/switches.js
+++ b/src/modules/switches.js
@@ -42,7 +42,7 @@ const SWITCH_LIST = [{
   constant: 'SUMMARY',
 }, {
   name: '--api-key',
-  about: 'Use a specific API key instead of the current Operator\'s API Key.',
+  about: 'Use another API key (or operator name) instead of the current Operator\'s API key.',
   constant: 'API_KEY',
   valueLabel: '<API key>',
 }, {


### PR DESCRIPTION
I.e: `--api-key test-user` instead of a literal string `--api-key PIr9GJXvBD4lWquZYLR2NRQVtW0C...`