### PR TITLE
v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ following usable methods and data:
   `['thngs', 'list']`.
 * `version` - String of the current running `evrythng-cli` version.
 * `requireVersion()` - Require a minimum version of the `evrythng-cli` to load.
+* `getCurrentOperator()` - Obtain an evrythng.js Operator scope for the
+  currently selected operator.
 
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 > Requires Node.js version 7.6 or greater
 
-Command Line Interface (CLI) for working with the 
-[EVRYTHNG API](https://developers.evrythng.com) from a terminal or scripts with 
+Command Line Interface (CLI) for working with the
+[EVRYTHNG API](https://developers.evrythng.com) from a terminal or scripts with
 ease.
 
 
@@ -16,7 +16,7 @@ $ npm i -g evrythng-cli
 ```
 
 Then add at least one Operator using an Operator API Key available
-from the 'Account Settings' page of the 
+from the 'Account Settings' page of the
 [EVRYTHNG Dashboard](https://dashboard.evrythng.com):
 
 ```
@@ -34,23 +34,23 @@ $ evrythng operators add prod us AGiWrH5OteA4aHiM...
 
 ## Usage and Help
 
-After installation, the global `npm` module can be used directly. In general, 
+After installation, the global `npm` module can be used directly. In general,
 the argument structure is:
 
 ```
 $ evrythng <command> <params>... [<payload>] [<switches>...]
 ```
 
-Run `evrythng` to see all commands, switches, and options. 
+Run `evrythng` to see all commands, switches, and options.
 
 
 ## Authentication
 
 Authentication is provided in two ways.
 
-1. Using the `operators` command to store Operator API Keys associated with 
-   different accounts and regions in the user's `~/.evrythng-cli-config` file. 
-   Any request that can be done as an Operator is done with the currently 
+1. Using the `operators` command to store Operator API Keys associated with
+   different accounts and regions in the user's `~/.evrythng-cli-config` file.
+   Any request that can be done as an Operator is done with the currently
    selected Operator.
 
 2. Using the `--api-key` switch to either override the currently selected
@@ -63,12 +63,12 @@ Authentication is provided in two ways.
 
 ## Plugins
 
-The EVRYTHNG CLI allows plugins to be created and installed in order to 
-add/extend custom functionality as the user requires. These plugins are provided 
-with an `api` parameter that contains methods and data they can use to implement 
+The EVRYTHNG CLI allows plugins to be created and installed in order to
+add/extend custom functionality as the user requires. These plugins are provided
+with an `api` parameter that contains methods and data they can use to implement
 additional functionality, such as adding new commands.
 
-See the 
+See the
 [_Plugins_](https://developers.evrythng.com/v3.0/docs/evrythng-cli-plugins#section-published-examples)
 page of the documentation for some example plugin implementations.
 
@@ -77,8 +77,8 @@ page of the documentation for some example plugin implementations.
 
 In order to be considered a plugin, its `npm` module must meet the following:
 
-* Be installed in the same directory as the CLI, as will be the case when 
-  installed globally with `-g` or as a project dependency (i.e: in 
+* Be installed in the same directory as the CLI, as will be the case when
+  installed globally with `-g` or as a project dependency (i.e: in
   `node_modules`).
 * Have a package name beginning the prefix `evrythng-cli-plugin-`.
 * Have a single source file identifyable when it is `require`d, such as setting
@@ -98,6 +98,10 @@ An example of such a plugin is shown below. The basic directory structure is:
 
 ```js
 module.exports = (api) => {
+  // Require minimum evrythng-cli version 1.6.0
+  api.requireVersion('1.6.0');
+
+  // Define a new command: 'greet $name'
   const newCommand = {
     about: 'Greet someone',
     firstArg: 'greet',
@@ -109,17 +113,17 @@ module.exports = (api) => {
     },
   };
 
-  // Register a new command
+  // Register the new command
   api.registerCommand(newCommand);
 };
 ```
 
-In the example above, a new command `greet` is added with one operation that 
-is provided the remaining arguments, in the same way as regular built-in 
-commands. This is validated against a schema before being loaded - it must match 
+In the example above, a new command `greet` is added with one operation that
+is provided the remaining arguments, in the same way as regular built-in
+commands. This is validated against a schema before being loaded - it must match
 the structure of the above example.
 
-The example command added in the example is then available as usual when using 
+The example command added in the example is then available as usual when using
 the CLI:
 
 ```
@@ -130,16 +134,18 @@ Hello there, Charles!
 
 ### Plugin API
 
-The `api` parameter provided to a plugin's exported function contains the 
+The `api` parameter provided to a plugin's exported function contains the
 following usable methods and data:
 
 * `registerCommand()` - Register a new command.
-* `getOptions()` - Retrieve an object describing the user's `options` from the 
+* `getOptions()` - Retrieve an object describing the user's `options` from the
   CLI configuration file, which defines the persistent `options` preferences.
 * `getSwitches()` - Retrieve an object describing the currently active switches.
 * `getConfig()` - Get a `get()`/`set()` interface to the config file.
-* `runCommand()` - Run a CLI command using a list of string arguments, such as 
+* `runCommand()` - Run a CLI command using a list of string arguments, such as
   `['thngs', 'list']`.
+* `version` - String of the current running `evrythng-cli` version.
+* `requireVersion()` - Require a minimum version of the `evrythng-cli` to load.
 
 
 ## Architecture
@@ -152,7 +158,7 @@ The structure of launch parameters is as follows:
 $ evrythng <command> <params>... [<payload>] [<switches>...]
 ```
 
-A command is implemented by adding to `commands.js`, and must have the following 
+A command is implemented by adding to `commands.js`, and must have the following
 exported structure:
 
 ```js
@@ -163,7 +169,7 @@ exported structure:
 }
 ```
 
-For example: 
+For example:
 
 ```js
 module.exports = {
@@ -178,12 +184,12 @@ module.exports = {
 };
 ```
 
-This is so that a command can safely implements its functionality using 
-parameters that were provided to it. A command is selected when all arguments 
+This is so that a command can safely implements its functionality using
+parameters that were provided to it. A command is selected when all arguments
 match the `pattern` provided by any given `operations` item, including keywords
 such as `$id` or `$type`.
 
-If no command is matched, the help text is displayed. If a command is not fully 
+If no command is matched, the help text is displayed. If a command is not fully
 matched, but the arguments do start with a module's `firstArg`, the syntax
 for the module's `operations` is printed to help guide the user.
 
@@ -191,8 +197,8 @@ So for example, the `thngs $id read` command:
 
 ```
 $ evrythng thngs UnghCKffVg8a9KwRwE5C9qBs read
-``` 
-would receive all tokens after its own name as `args` when the operation is 
+```
+would receive all tokens after its own name as `args` when the operation is
 called (i.e: all arguments matched its `pattern`):
 
 ```
@@ -221,28 +227,28 @@ or as entirely new commands that are all agnostic to each other.
 ### Requests
 
 HTTP requests are performed using the `post`, `get`, `put`, and `delete` methods
-exported by `src/modules/http.js`. 
+exported by `src/modules/http.js`.
 
-Switches that affect pre- and post-request behavior (such as printing extra 
-logs, applying query params, or formatting the API response) are handled 
-transparently in this module, so the commands do not have to handle them 
+Switches that affect pre- and post-request behavior (such as printing extra
+logs, applying query params, or formatting the API response) are handled
+transparently in this module, so the commands do not have to handle them
 themselves.
 
 
 ### Use of Swagger
 
-The EVRYTHNG CLI uses the 
-[`evrythng-swagger` `npm` module](https://www.npmjs.com/package/evrythng-swagger) 
-to allow interactive building of `POST` request payloads using the `definitions` 
-provided by the EVRYTHNG `swagger.json` API description. This is invoked with 
+The EVRYTHNG CLI uses the
+[`evrythng-swagger` `npm` module](https://www.npmjs.com/package/evrythng-swagger)
+to allow interactive building of `POST` request payloads using the `definitions`
+provided by the EVRYTHNG `swagger.json` API description. This is invoked with
 the `--build` switch:
 
 ```
 $ evrythng thngs create --build
 ```
 
-The CLI then asks for each field in the `definition` (that is not marked as 
-`readOnly`) specified in the command that implements `payloadBuilder.build()`, 
+The CLI then asks for each field in the `definition` (that is not marked as
+`readOnly`) specified in the command that implements `payloadBuilder.build()`,
 in this case `ThngDocument`:
 
 ```js
@@ -255,7 +261,7 @@ createThng: {
 },
 ```
 
-The user is then asked to input their values, including sub-objects such as 
+The user is then asked to input their values, including sub-objects such as
 `customFields`:
 
 ```
@@ -300,11 +306,11 @@ Provide values for each field (or leave blank to skip):
 
 ### Switches
 
-Any launch parameter that begins with `--` is treated as a switch, and is 
+Any launch parameter that begins with `--` is treated as a switch, and is
 extracted from the launch parameters by `switches.js` in the `extract()` method
 before the remaining `args` are provided to the matched command.
 
-After `extract()` is called, a switch's state in any given invocation can be 
+After `extract()` is called, a switch's state in any given invocation can be
 determined as shown below for an example command:
 
 ```
@@ -319,8 +325,8 @@ if (switches.SCOPES) {
 }
 ```
 
-If a switch is configured in `SWITCH_LIST` to be given with a value 
-(`hasValue`), it is made available as `value`. This is specified at invocation 
+If a switch is configured in `SWITCH_LIST` to be given with a value
+(`hasValue`), it is made available as `value`. This is specified at invocation
 time as follows:
 
 ```
@@ -346,7 +352,7 @@ Filter value was tags=test
 
 ### Running Tests
 
-Run `npm test` to run the Mocha tests in the `tests` directory. Ensure `use` an 
+Run `npm test` to run the Mocha tests in the `tests` directory. Ensure `use` an
 appropriate Operator first!
 
 Afterwards, see `reports/index.html` for code coverage results.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ following usable methods and data:
 * `runCommand()` - Run a CLI command using a list of string arguments, such as
   `['thngs', 'list']`.
 * `version` - String of the current running `evrythng-cli` version.
-* `requireVersion()` - Require a minimum version of the `evrythng-cli` to load.
+* `requireVersion()` - Require a semver compatible version of `evrythng-cli` to
+  load the plugin.
 * `getOperatorScope()` - Obtain an evrythng.js Operator scope for the currently
   selected operator.
 

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ following usable methods and data:
   `['thngs', 'list']`.
 * `version` - String of the current running `evrythng-cli` version.
 * `requireVersion()` - Require a minimum version of the `evrythng-cli` to load.
-* `getCurrentOperator()` - Obtain an evrythng.js Operator scope for the
-  currently selected operator.
+* `getOperatorScope()` - Obtain an evrythng.js Operator scope for the currently
+  selected operator.
 
 
 ## Architecture

--- a/package-lock.json
+++ b/package-lock.json
@@ -1903,9 +1903,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2861,6 +2861,11 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,9 +81,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
-      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -1070,9 +1070,9 @@
       "dev": true
     },
     "evrythng": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/evrythng/-/evrythng-5.0.0.tgz",
-      "integrity": "sha512-mH8oAaPaDqzpC169Ke9kfCVjvPTpdrfyJ4oNa+5TYqwZXNQ11FPnVBPf62BDl0XKewg6Ykg8GcWF9JSylmpHPA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/evrythng/-/evrythng-5.4.0.tgz",
+      "integrity": "sha512-TQ7AhnWKdTHzpSmUHho3zERTimAmlqVhaq7dSmcGHgVx80XqqjXLZeOKMcayKKCw4l97biDri3tyXOFQRd/fgw==",
       "requires": {
         "@babel/runtime": "^7.4.3",
         "isomorphic-fetch": "^2.2.1",
@@ -2740,9 +2740,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regexpp": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng-cli",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -885,6 +885,14 @@
         "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
         "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "eslint-config-airbnb-base": {
@@ -1110,6 +1118,14 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "dev": true
+            }
           }
         }
       }
@@ -2209,6 +2225,12 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
         }
       }
     },
@@ -2227,6 +2249,14 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "npm-run-path": {
@@ -2856,15 +2886,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true
-    },
-    "semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jsonschema": "^1.2.4",
     "lodash": "^4.17.15",
     "neat-csv": "^3.0.0",
-    "semver-compare": "^1.0.0"
+    "semver": "^6.3.0"
   },
   "devDependencies": {
     "@evrythng/eslint-config-evrythng": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng-cli",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Extensible command line interface for the EVRYTHNG API.",
   "main": "./src/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "json-schema-ref-parser": "^5.0.3",
     "jsonschema": "^1.2.4",
     "lodash": "^4.17.15",
-    "neat-csv": "^3.0.0"
+    "neat-csv": "^3.0.0",
+    "semver-compare": "^1.0.0"
   },
   "devDependencies": {
     "@evrythng/eslint-config-evrythng": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "author": "EVRYTHNG",
   "dependencies": {
-    "evrythng": "^5.0.0",
+    "evrythng": "^5.4.0",
     "evrythng-swagger": "^1.0.0",
     "json-schema-ref-parser": "^5.0.3",
     "jsonschema": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "evrythng-cli",
   "version": "1.6.0",
-  "description": "CLI for the EVRYTHNG API.",
+  "description": "Extensible command line interface for the EVRYTHNG API.",
   "main": "./src/main.js",
   "scripts": {
+    "show-notice": "echo '\n  Thank you for using evrythng-cli! Type `evrythng` to get started!\n'",
+    "postinstall": "npm run --silent show-notice",
     "start": "node ./src/main.js",
     "lint": "./node_modules/.bin/eslint src/",
     "test": "./node_modules/.bin/nyc ./node_modules/.bin/_mocha tests/main.js --slow 5000 --timeout 10000"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "evrythng-swagger": "^1.0.0",
     "json-schema-ref-parser": "^5.0.3",
     "jsonschema": "^1.2.4",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "neat-csv": "^3.0.0"
   },
   "devDependencies": {

--- a/src/commands/operator.js
+++ b/src/commands/operator.js
@@ -105,10 +105,8 @@ const addOperator = async (args) => {
   config.set('operators', operators);
   logger.info(`\nAdded operator '${name}' in region '${region}'`);
 
-  // If this is the first one, automatically use it.
-  if (Object.keys(operators).length === 1) {
-    useOperator([name]);
-  }
+  // Automatically use it (likely we want to work with it right now)
+  useOperator([name]);
 
   return operators[name];
 };

--- a/src/commands/product.js
+++ b/src/commands/product.js
@@ -108,20 +108,37 @@ module.exports = {
 
     // Product redirection
     createProductRedirection: {
-      execute: async ([id, , , json]) => http.post(`/products/${id}/redirector`, JSON.parse(json)),
-      pattern: '$id redirection create $payload',
+      execute: async ([id, , shortDomain, , json]) => {
+        const body = Object.assign(JSON.parse(json), { evrythngId: id, type: 'product' });
+        return http.shortDomainRequest(shortDomain, {
+          method: 'post',
+          body: JSON.stringify(body),
+        });
+      },
+      pattern: '$id redirections $shortDomain create $payload',
     },
-    readProductRedirection: {
-      execute: async ([id]) => http.get(`/products/${id}/redirector`),
-      pattern: '$id redirection read',
+    listProductRedirections: {
+      execute: async ([id, , shortDomain]) => http.shortDomainRequest(shortDomain, {
+        params: { evrythngId: id },
+      }),
+      pattern: '$id redirections $shortDomain list',
     },
     updateProductRedirection: {
-      execute: async ([id, , , json]) => http.put(`/products/${id}/redirector`, JSON.parse(json)),
-      pattern: '$id redirection update $payload',
+      execute: async ([id, , shortDomain, shortId, , body]) => {
+        return http.shortDomainRequest(shortDomain, {
+          url: `/redirections/${shortId}`,
+          method: 'put',
+          body,
+        })
+      },
+      pattern: '$id redirections $shortDomain $shortId update $payload',
     },
     deleteProductRedirection: {
-      execute: async ([id]) => http.delete(`/products/${id}/redirector`),
-      pattern: '$id redirection delete',
+      execute: async ([id, , shortDomain, shortId]) => http.shortDomainRequest(shortDomain, {
+        url: `/redirections/${shortId}`,
+        method: 'delete',
+      }),
+      pattern: '$id redirections $shortDomain $shortId delete',
     },
   },
 };

--- a/src/commands/thng.js
+++ b/src/commands/thng.js
@@ -3,6 +3,7 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
+const evrythng = require('evrythng');
 const csvFile = require('../modules/csvFile');
 const http = require('../modules/http');
 const jsonFile = require('../modules/jsonFile');
@@ -108,20 +109,37 @@ module.exports = {
 
     // Thng redirection
     createThngRedirection: {
-      execute: async ([id, , , json]) => http.post(`/thngs/${id}/redirector`, JSON.parse(json)),
-      pattern: '$id redirection create $payload',
+      execute: async ([id, , shortDomain, , json]) => {
+        const body = Object.assign(JSON.parse(json), { evrythngId: id, type: 'thng' });
+        return http.shortDomainRequest(shortDomain, {
+          method: 'post',
+          body: JSON.stringify(body),
+        });
+      },
+      pattern: '$id redirections $shortDomain create $payload',
     },
-    readThngRedirection: {
-      execute: async ([id]) => http.get(`/thngs/${id}/redirector`),
-      pattern: '$id redirection read',
+    listThngRedirections: {
+      execute: async ([id, , shortDomain]) => http.shortDomainRequest(shortDomain, {
+        params: { evrythngId: id },
+      }),
+      pattern: '$id redirections $shortDomain list',
     },
     updateThngRedirection: {
-      execute: async ([id, , , json]) => http.put(`/thngs/${id}/redirector`, JSON.parse(json)),
-      pattern: '$id redirection update $payload',
+      execute: async ([id, , shortDomain, shortId, , body]) => {
+        return http.shortDomainRequest(shortDomain, {
+          url: `/redirections/${shortId}`,
+          method: 'put',
+          body,
+        })
+      },
+      pattern: '$id redirections $shortDomain $shortId update $payload',
     },
     deleteThngRedirection: {
-      execute: async ([id]) => http.delete(`/thngs/${id}/redirector`),
-      pattern: '$id redirection delete',
+      execute: async ([id, , shortDomain, shortId]) => http.shortDomainRequest(shortDomain, {
+        url: `/redirections/${shortId}`,
+        method: 'delete',
+      }),
+      pattern: '$id redirections $shortDomain $shortId delete',
     },
 
     // Thng location

--- a/src/functions/printHelp.js
+++ b/src/functions/printHelp.js
@@ -6,6 +6,7 @@
 const { COMMAND_LIST } = require('../modules/commands');
 const { OPTION_LIST } = require('../commands/option');
 const { SWITCH_LIST } = require('../modules/switches');
+const config = require('../modules/config');
 const indent = require('./indent');
 const logger = require('../modules/logger');
 const { description, name, version } = require('../../package.json');
@@ -73,12 +74,6 @@ module.exports = () => {
   logger.info(indent('Specify a command name below to see syntax for all its operations.\n', 4));
   formatList(COMMAND_LIST.filter(item => !item.fromPlugin), 'firstArg', 'about');
 
-  const thirdPartyCommands = COMMAND_LIST.filter(item => item.fromPlugin);
-  if (thirdPartyCommands.length) {
-    logger.info('\nAvailable Plugin Commands:\n');
-    formatList(thirdPartyCommands, 'firstArg', 'about');
-  }
-
   logger.info('\nAvailable Switches:\n');
   const switchList = SWITCH_LIST.map((item) => {
     item.name = `${item.name}${item.valueLabel ? ` ${item.valueLabel}` : ''}`;
@@ -92,4 +87,14 @@ module.exports = () => {
 
   logger.info('\nUsage Examples:\n');
   formatList(EXAMPLES, 'about', 'command', false);
+
+  const pluginCommands = COMMAND_LIST.filter(item => item.fromPlugin);
+  if (pluginCommands.length) {
+    logger.info('\nAvailable Plugin Commands:\n');
+    formatList(pluginCommands, 'firstArg', 'about');
+  }
+
+  const using = config.get('using');
+  const { region } = config.get('operators')[using];
+  logger.info(`\n\nUsing Operator '${using}' (region: ${region})\n`);
 };

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -123,7 +123,7 @@ const API = {
    *
    * @returns {object} Operator scope for the currently selected operator.
    */
-  getCurrentOperator: async () => {
+  getOperatorScope: async () => {
     operator.applyRegion();
     const op = new evrythng.Operator(operator.getKey());
     await op.init();

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -124,9 +124,8 @@ const API = {
    * @returns {object} Operator scope for the currently selected operator.
    */
   getCurrentOperator: async () => {
-    const { apiKey } = operator.getCurrent();
     operator.applyRegion();
-    const op = new evrythng.Operator(apiKey);
+    const op = new evrythng.Operator(operator.getKey());
     await op.init();
     return op;
   },

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -3,6 +3,7 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
+const evrythng = require('evrythng');
 const fs = require('fs');
 const semverCompare = require('semver-compare');
 const { validate } = require('./util');
@@ -114,6 +115,20 @@ const API = {
     if (semverCompare(version, spec) < 0) {
       throw new Error(`This plugin requires evrythng-cli version ${spec} or above. You are using version ${version}.`);
     }
+  },
+
+  /**
+   * Convenience method to get the current Operator as an SDK scope.
+   * The region is automatically applied.
+   *
+   * @returns {object} Operator scope for the currently selected operator.
+   */
+  getCurrentOperator: async () => {
+    const { apiKey } = operator.getCurrent();
+    operator.applyRegion();
+    const op = new evrythng.Operator(apiKey);
+    await op.init();
+    return op;
   },
 };
 

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -5,7 +5,7 @@
 
 const evrythng = require('evrythng');
 const fs = require('fs');
-const semverCompare = require('semver-compare');
+const semver = require('semver');
 const { validate } = require('./util');
 const commands = require('./commands');
 const config = require('./config');
@@ -112,7 +112,7 @@ const API = {
    * @throws If the version required is less than the current running CLI version.
    */
   requireVersion: (spec) => {
-    if (semverCompare(version, spec) < 0) {
+    if (!semver.satisfies(version, spec)) {
       throw new Error(`This plugin requires evrythng-cli version ${spec} or above. You are using version ${version}.`);
     }
   },

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -22,16 +22,13 @@ const DEFAULT_CONFIG = {
 };
 
 const CONFIG_SCHEMA = {
-  type: 'object',
   additionalProperties: false,
   required: ['using', 'operators', 'options', 'regions'],
   properties: {
     using: { type: 'string' },
     operators: {
-      type: 'object',
       patternProperties: {
         '(.*)': {
-          type: 'object',
           additionalProperties: false,
           required: ['apiKey', 'region'],
           properties: {
@@ -46,7 +43,6 @@ const CONFIG_SCHEMA = {
       },
     },
     options: {
-      type: 'object',
       additionalProperties: false,
       required: ['errorDetail', 'noConfirm', 'showHttp', 'logLevel', 'defaultPerPage'],
       properties: {

--- a/src/modules/switches.js
+++ b/src/modules/switches.js
@@ -44,7 +44,7 @@ const SWITCH_LIST = [{
   name: '--api-key',
   about: 'Use another API key (or operator name) instead of the current Operator\'s API key.',
   constant: 'API_KEY',
-  valueLabel: '<API key>',
+  valueLabel: '<API key|operator name>',
 }, {
   name: '--expand',
   about: 'Expand some ID fields, timestamps to date, etc.',

--- a/tests/commands/product.js
+++ b/tests/commands/product.js
@@ -3,6 +3,7 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
+const nock = require('nock');
 const { ID, NAME, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 const switches = require('../../src/modules/switches');
@@ -125,39 +126,50 @@ describe('products', () => {
   });
 
   // Product redirection
-  it('should make correct request for \'products $id redirection create $payload\'', async () => {
-    const payload = JSON.stringify({ defaultRedirectUrl: 'https://google.com/{shortId}/' });
-    mockApi()
-      .post(`/products/${ID}/redirector`, payload)
-      .reply(201, {});
+  it('should make correct request for \'products $id redirections $shortDomain create $payload\'',
+    async () => {
+      const payload = JSON.stringify({
+        defaultRedirectUrl: 'https://google.com/{shortId}/',
+        type: 'product',
+        evrythngId: ID
+      });
+      nock('https://tn.gg')
+        .post('/redirections', payload)
+        .reply(201, {});
 
-    await cli(`products ${ID} redirection create ${payload}`);
+      await cli(`products ${ID} redirections tn.gg create ${payload}`);
+    }
+  );
+
+  it('should make correct request for \'products $id redirections $shortDomain list\'', async () => {
+    nock('https://tn.gg')
+      .get(`/redirections?evrythngId=${ID}`)
+      .reply(200, [{}]);
+
+    await cli(`products ${ID} redirections tn.gg list`);
   });
 
-  it('should make correct request for \'products $id redirection read\'', async () => {
-    mockApi()
-      .get(`/products/${ID}/redirector?perPage=30`)
-      .reply(200, {});
+  it(
+    'should make correct request for \'products $id redirections $shortDomain $shortId update $payload\'',
+    async () => {
+      const payload = JSON.stringify({ defaultRedirectUrl: 'https://google.com/{shortId}/updates/' });
+      nock('https://tn.gg')
+        .put('/redirections/foo', payload)
+        .reply(200, {});
 
-    await cli(`products ${ID} redirection read`);
-  });
+      await cli(`products ${ID} redirections tn.gg foo update ${payload}`);
+    }
+  );
 
-  it('should make correct request for \'products $id redirection update $payload\'', async () => {
-    const payload = JSON.stringify({ defaultRedirectUrl: 'https://google.com/{shortId}/updates/' });
-    mockApi()
-      .put(`/products/${ID}/redirector`, payload)
-      .reply(200, {});
+  it('should make correct request for \'products $id redirections $shortDomain $shortId delete\'',
+    async () => {
+      nock('https://tn.gg')
+        .delete(`/redirections/foo`)
+        .reply(200);
 
-    await cli(`products ${ID} redirection update ${payload}`);
-  });
-
-  it('should make correct request for \'products $id redirection delete\'', async () => {
-    mockApi()
-      .delete(`/products/${ID}/redirector`)
-      .reply(200, {});
-
-    await cli(`products ${ID} redirection delete`);
-  });
+      await cli(`products ${ID} redirections tn.gg foo delete`);
+    }
+  );
 
   // Finally
   it('should make correct request for \'products $id delete\'', async () => {

--- a/tests/commands/thng.js
+++ b/tests/commands/thng.js
@@ -3,6 +3,7 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
+const nock = require('nock');
 const { ID, NAME, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 const switches = require('../../src/modules/switches');
@@ -124,39 +125,50 @@ describe('thngs', () => {
   });
 
   // Thng redirection
-  it('should make correct request for \'thngs $id redirection create $payload\'', async () => {
-    const payload = JSON.stringify({ defaultRedirectUrl: 'https://google.com/{shortId}/' });
-    mockApi()
-      .post(`/thngs/${ID}/redirector`, payload)
-      .reply(201, {});
+  it('should make correct request for \'thngs $id redirections $shortDomain create $payload\'',
+    async () => {
+      const payload = JSON.stringify({
+        defaultRedirectUrl: 'https://google.com/{shortId}/',
+        type: 'thng',
+        evrythngId: ID
+      });
+      nock('https://tn.gg')
+        .post('/redirections', payload)
+        .reply(201, {});
 
-    await cli(`thngs ${ID} redirection create ${payload}`);
+      await cli(`thngs ${ID} redirections tn.gg create ${payload}`);
+    }
+  );
+
+  it('should make correct request for \'thngs $id redirections $shortDomain list\'', async () => {
+    nock('https://tn.gg')
+      .get(`/redirections?evrythngId=${ID}`)
+      .reply(200, [{}]);
+
+    await cli(`thngs ${ID} redirections tn.gg list`);
   });
 
-  it('should make correct request for \'thngs $id redirection read\'', async () => {
-    mockApi()
-      .get(`/thngs/${ID}/redirector?perPage=30`)
-      .reply(200, {});
+  it(
+    'should make correct request for \'thngs $id redirections $shortDomain $shortId update $payload\'',
+    async () => {
+      const payload = JSON.stringify({ defaultRedirectUrl: 'https://google.com/{shortId}/updates/' });
+      nock('https://tn.gg')
+        .put('/redirections/foo', payload)
+        .reply(200, {});
 
-    await cli(`thngs ${ID} redirection read`);
-  });
+      await cli(`thngs ${ID} redirections tn.gg foo update ${payload}`);
+    }
+  );
 
-  it('should make correct request for \'thngs $id redirection update $payload\'', async () => {
-    const payload = JSON.stringify({ defaultRedirectUrl: 'https://google.com/{shortId}/updates/' });
-    mockApi()
-      .put(`/thngs/${ID}/redirector`, payload)
-      .reply(200, {});
+  it('should make correct request for \'thngs $id redirections $shortDomain $shortId delete\'',
+    async () => {
+      nock('https://tn.gg')
+        .delete(`/redirections/foo`)
+        .reply(200);
 
-    await cli(`thngs ${ID} redirection update ${payload}`);
-  });
-
-  it('should make correct request for \'thngs $id redirection delete\'', async () => {
-    mockApi()
-      .delete(`/thngs/${ID}/redirector`)
-      .reply(200, {});
-
-    await cli(`thngs ${ID} redirection delete`);
-  });
+      await cli(`thngs ${ID} redirections tn.gg foo delete`);
+    }
+  );
 
   // Thng location
   it('should make correct request for \'thngs $id location read\'', async () => {

--- a/tests/modules/api.js
+++ b/tests/modules/api.js
@@ -102,4 +102,24 @@ describe('api', () => {
     const using = config.get('using');
     expect(using).to.be.a('string');
   });
+
+  it('should provide access to the current CLI version', () => {
+    const { version } = api.API;
+
+    expect(version).to.be.a('string');
+  });
+
+  it('should accept a lesser plugin version requirement', () => {
+    const { version, requireVersion } = api.API;
+
+    expect(() => requireVersion(version)).to.not.throw();
+  });
+
+  it('should reject a larger plugin version requirement than the current', () => {
+    const { version, requireVersion } = api.API;
+    const [major, minor, patch] = version.split('.');
+    const futureVersion = `${major}.${parseInt(minor) + 1}.${patch}`;
+
+    expect(() => requireVersion(futureVersion)).to.throw();
+  });
 });

--- a/tests/modules/api.js
+++ b/tests/modules/api.js
@@ -123,6 +123,14 @@ describe('api', () => {
     expect(() => requireVersion(futureVersion)).to.throw();
   });
 
+  it('should reject a semver incompatible major requirement', () => {
+    const { version, requireVersion } = api.API;
+    const [major, minor, patch] = version.split('.');
+    const futureVersion = `${major + 1}.${minor}.${patch}`;
+
+    expect(() => requireVersion(futureVersion)).to.throw();
+  });
+
   it('should provide access to the current Operator scope', async () => {
     mockApi()
       .persist()

--- a/tests/modules/api.js
+++ b/tests/modules/api.js
@@ -129,7 +129,7 @@ describe('api', () => {
       .get('/access')
       .reply(200, { actor: { id: 'foo' } });
 
-    const op = await api.API.getCurrentOperator();
+    const op = await api.API.getOperatorScope();
 
     expect(op.actor.id).to.equal('foo');
     expect(op.apiKey).to.have.length(80);

--- a/tests/modules/api.js
+++ b/tests/modules/api.js
@@ -122,4 +122,16 @@ describe('api', () => {
 
     expect(() => requireVersion(futureVersion)).to.throw();
   });
+
+  it('should provide access to the current Operator scope', async () => {
+    mockApi()
+      .persist()
+      .get('/access')
+      .reply(200, { actor: { id: 'foo' } });
+
+    const op = await api.API.getCurrentOperator();
+
+    expect(op.actor.id).to.equal('foo');
+    expect(op.apiKey).to.have.length(80);
+  });
 });


### PR DESCRIPTION
_Features_
- Use evrythng.js@5.4.0
- Add `postinstall` message to help getting started
- Always switch to a newly added `operator`
- Add `version`, `requireVersion()`, and `getOperatorScope()` to the plugin API.
- Show the currently selected operator in the help text (`evrythng`)

_Fixes_
- Fix `npm audit` warnings
- Reorder help text to better show installed plugins
- `redirections` always use the supplied short domain, instead of assuming the default.

_TODO_
- [ ] Bump version after review