### PR TITLE
Add operations and tests for ADI Orders API

### DIFF
--- a/src/commands/adi-order.js
+++ b/src/commands/adi-order.js
@@ -1,0 +1,23 @@
+/**
+ * (c) Copyright Reserved EVRYTHNG Limited 2018.
+ * All rights reserved. Use of this material is subject to license.
+ */
+
+const http = require('../modules/http');
+const util = require('../modules/util');
+
+module.exports = {
+  about: 'Work with ADI orders.',
+  firstArg: 'adi-orders',
+  operations: {
+    createAdiOrder: {
+      execute: async ([, json]) => http.post('/adis/orders', JSON.parse(json)),
+      pattern: 'create $payload',
+      helpPattern: 'create $payload',
+    },
+    readAdiOrder: {
+      execute: async ([id]) => http.get(`/adis/orders/${id}`),
+      pattern: '$id read',
+    },
+  },
+};

--- a/src/commands/adi-order.js
+++ b/src/commands/adi-order.js
@@ -19,5 +19,11 @@ module.exports = {
       execute: async ([id]) => http.get(`/adis/orders/${id}`),
       pattern: '$id read',
     },
+
+    createAdiOrderEvent: {
+      execute: async ([id, , , json]) => http.post(`/adis/orders/${id}/events`, JSON.parse(json)),
+      pattern: '$id events create $payload',
+      helpPattern: '$id events create $payload',
+    },
   },
 };

--- a/src/commands/adi-order.js
+++ b/src/commands/adi-order.js
@@ -13,7 +13,6 @@ module.exports = {
     createAdiOrder: {
       execute: async ([, json]) => http.post('/adis/orders', JSON.parse(json)),
       pattern: 'create $payload',
-      helpPattern: 'create $payload',
     },
     readAdiOrder: {
       execute: async ([id]) => http.get(`/adis/orders/${id}`),
@@ -23,7 +22,6 @@ module.exports = {
     createAdiOrderEvent: {
       execute: async ([id, , , json]) => http.post(`/adis/orders/${id}/events`, JSON.parse(json)),
       pattern: '$id events create $payload',
-      helpPattern: '$id events create $payload',
     },
   },
 };

--- a/src/modules/commands.js
+++ b/src/modules/commands.js
@@ -11,6 +11,7 @@ const COMMAND_LIST = [
   require('../commands/account'),
   require('../commands/action'),
   require('../commands/action-type'),
+  require('../commands/adi-order'),
   require('../commands/app-user'),
   require('../commands/batch'),
   require('../commands/collection'),

--- a/src/modules/http.js
+++ b/src/modules/http.js
@@ -78,6 +78,9 @@ const buildQueryParams = (method, url) => {
   if (switches.CONTEXT) {
     result.context = true;
   }
+  if (switches.WITH_ERRORS) {
+    result.withErrors = true;
+  }
   if (ids) {
     result.ids = ids;
   }

--- a/src/modules/switches.js
+++ b/src/modules/switches.js
@@ -3,96 +3,131 @@
  * All rights reserved. Use of this material is subject to license.
  */
 
-const SWITCH_LIST = [{
-  name: '--filter',
-  about: 'Specify a Platform filter, such as \'tags=test\'.',
-  constant: 'FILTER',
-  valueLabel: '<query>',
-}, {
-  name: '--per-page',
-  about: 'Specify number of resources per page.',
-  constant: 'PER_PAGE',
-  valueLabel: '<count>',
-}, {
-  name: '--project',
-  about: 'Specify the \'project\' query parameter.',
-  constant: 'PROJECT',
-  valueLabel: '<project ID>',
-}, {
-  name: '--with-scopes',
-  about: 'Include resource scopes in the response.',
-  constant: 'SCOPES',
-}, {
-  name: '--context',
-  about: 'Specify the \'context=true\' query parameter.',
-  constant: 'CONTEXT',
-}, {
-  name: '--page',
-  about: 'Iterate to a specific page of results.',
-  constant: 'PAGE',
-  valueLabel: '<page>',
-}, {
-  name: '--ids',
-  about: 'Specify the \'ids\' query parameter with a list of specific IDs.',
-  constant: 'IDS',
-  valueLabel: '<list of IDs>',
-}, {
-  name: '--summary',
-  about: 'Show a list of resources as a summarised (id, name) single-line format.',
-  constant: 'SUMMARY',
-}, {
-  name: '--api-key',
-  about: 'Use another API key (or operator name) instead of the current Operator\'s API key.',
-  constant: 'API_KEY',
-  valueLabel: '<API key|operator name>',
-}, {
-  name: '--expand',
-  about: 'Expand some ID fields, timestamps to date, etc.',
-  constant: 'EXPAND',
-}, {
-  name: '--build',
-  about: 'Interactively build a create request payload using evrythng/swagger',
-  constant: 'BUILD',
-}, {
-  name: '--field',
-  about: 'Print only a certain field from the response.',
-  constant: 'FIELD',
-  valueLabel: '<key>',
-}, {
-  name: '--simple',
-  about: 'Print response in non-JSON friendly format.',
-  constant: 'SIMPLE',
-}, {
-  name: '--to-csv',
-  about: 'Output array response to a CSV file, such as \'./data.csv\'.',
-  constant: 'TO_CSV',
-  valueLabel: '<output file>',
-}, {
-  name: '--to-page',
-  about: 'Read up to 30 pages before returning results (only with --to-csv).',
-  constant: 'TO_PAGE',
-  valueLabel: '<page>',
-}, {
-  name: '--from-csv',
-  about: 'Load resources from a CSV file that was previously exported with --to-csv.',
-  constant: 'FROM_CSV',
-  valueLabel: '<input file>',
-}, {
-  name: '--with-redirections',
-  about: 'When importing/exporting, include each resource\'s redirection URL.',
-  constant: 'WITH_REDIRECTIONS',
-  valueLabel: '<short domain>',
-}, {
-  name: '--from-json',
-  about: 'Load resource from a JSON array file.',
-  constant: 'FROM_JSON',
-  valueLabel: '<input file>',
-}, {
-  name: '--to-json',
-  about: 'Output array response to a JSON file as an array.',
-  constant: 'TO_JSON',
-  valueLabel: '<input file>',
-}];
+/**
+ * List of switches available.
+ *
+ * New ones must also be implemented in buildQueryParams() in http.js
+ **/
+const SWITCH_LIST = [
+  // Platform query parameters
+  {
+    name: '--filter',
+    about: 'Specify a Platform filter, such as \'tags=test\'.',
+    constant: 'FILTER',
+    valueLabel: '<query>',
+  },
+  {
+    name: '--per-page',
+    about: 'Specify number of resources per page.',
+    constant: 'PER_PAGE',
+    valueLabel: '<count>',
+  },
+  {
+    name: '--project',
+    about: 'Specify the \'project\' query parameter.',
+    constant: 'PROJECT',
+    valueLabel: '<project ID>',
+  },
+  {
+    name: '--with-scopes',
+    about: 'Include resource scopes in the response.',
+    constant: 'SCOPES',
+  },
+  {
+    name: '--context',
+    about: 'Specify the \'context=true\' query parameter.',
+    constant: 'CONTEXT',
+  },
+  {
+    name: '--page',
+    about: 'Iterate to a specific page of results.',
+    constant: 'PAGE',
+    valueLabel: '<page>',
+  },
+  {
+    name: '--ids',
+    about: 'Specify the \'ids\' query parameter with a list of specific IDs.',
+    constant: 'IDS',
+    valueLabel: '<list of IDs>',
+  },
+  {
+    name: '--with-errors',
+    about: 'Specify the \'withErrors=true\' query parameter.',
+    constant: 'WITH_ERRORS',
+  },
+
+  // CLI helper switches
+  {
+    name: '--summary',
+    about: 'Show a list of resources as a summarised (id, name) single-line format.',
+    constant: 'SUMMARY',
+  },
+  {
+    name: '--api-key',
+    about: 'Use another API key (or operator name) instead of the current Operator\'s API key.',
+    constant: 'API_KEY',
+    valueLabel: '<API key|operator name>',
+  },
+  {
+    name: '--expand',
+    about: 'Expand some ID fields, timestamps to date, etc.',
+    constant: 'EXPAND',
+  },
+  {
+    name: '--build',
+    about: 'Interactively build a create request payload using evrythng/swagger',
+    constant: 'BUILD',
+  },
+  {
+    name: '--field',
+    about: 'Print only a certain field from the response.',
+    constant: 'FIELD',
+    valueLabel: '<key>',
+  },
+  {
+    name: '--simple',
+    about: 'Print response in non-JSON friendly format.',
+    constant: 'SIMPLE',
+  },
+
+  // Import/export switches
+  {
+    name: '--to-csv',
+    about: 'Output array response to a CSV file, such as \'./data.csv\'.',
+    constant: 'TO_CSV',
+    valueLabel: '<output file>',
+  },
+  {
+    name: '--to-page',
+    about: 'Read up to 30 pages before returning results (only with --to-csv).',
+    constant: 'TO_PAGE',
+    valueLabel: '<page>',
+  },
+  {
+    name: '--from-csv',
+    about: 'Load resources from a CSV file that was previously exported with --to-csv.',
+    constant: 'FROM_CSV',
+    valueLabel: '<input file>',
+  },
+  {
+    name: '--with-redirections',
+    about: 'When importing/exporting, include each resource\'s redirection URL.',
+    constant: 'WITH_REDIRECTIONS',
+    valueLabel: '<short domain>',
+  },
+  {
+    name: '--from-json',
+    about: 'Load resource from a JSON array file.',
+    constant: 'FROM_JSON',
+    valueLabel: '<input file>',
+  },
+  {
+    name: '--to-json',
+    about: 'Output array response to a JSON file as an array.',
+    constant: 'TO_JSON',
+    valueLabel: '<input file>',
+  }
+];
 
 const apply = (args) => {
   args

--- a/tests/commands/adi-order.js
+++ b/tests/commands/adi-order.js
@@ -1,0 +1,26 @@
+/**
+ * (c) Copyright Reserved EVRYTHNG Limited 2018.
+ * All rights reserved. Use of this material is subject to license.
+ */
+
+const { ID, mockApi } = require('../util');
+const cli = require('../../src/functions/cli');
+
+describe('adi-orders', async () => {
+  it('should make correct request for \'adi-orders create $payload\'', async () => {
+    const payload = JSON.stringify({ name: 'Test batch' });
+    mockApi()
+      .post('/adis/orders', payload)
+      .reply(201, {});
+
+    await cli(`adi-orders create ${payload}`);
+  });
+
+  it('should make correct request for \'adi-orders $id read\'', async () => {
+    mockApi()
+      .get(`/adis/orders/${ID}`)
+      .reply(200, {});
+
+    await cli(`adi-orders ${ID} read`);
+  });
+});

--- a/tests/commands/adi-order.js
+++ b/tests/commands/adi-order.js
@@ -8,7 +8,31 @@ const cli = require('../../src/functions/cli');
 
 describe('adi-orders', async () => {
   it('should make correct request for \'adi-orders create $payload\'', async () => {
-    const payload = JSON.stringify({ name: 'Test batch' });
+    const payload = JSON.stringify({
+      ids: [
+        'serial1',
+        'serial2'
+      ],
+      purchaseOrder: '234567890',
+      metadata: {
+        identifierKey: 'gs1:21',
+        customFields: {
+          factory: '0400321'
+        },
+        product: 'gs1:01:9780345418913',
+        tags: [
+          'factory:0400321'
+        ],
+        shortDomain: 'tn.gg',
+        defaultRedirectUrl: 'https://evrythng.com?id={shortId}'
+      },
+      identifiers: {
+        internalId: 'X7JF'
+      },
+      tags: [
+        'X7JF'
+      ]
+    });
     mockApi()
       .post('/adis/orders', payload)
       .reply(201, {});
@@ -22,5 +46,27 @@ describe('adi-orders', async () => {
       .reply(200, {});
 
     await cli(`adi-orders ${ID} read`);
+  });
+
+  it('should make correct request for \'adi-orders $id events create $payload\'', async () => {
+    const payload = JSON.stringify({
+      metadata: {
+        type: 'encodings',
+        tags: ['example']
+      },
+      ids: [
+        'serial1',
+        'serial2'
+      ],
+      customFields: {
+        internalId: 'X7JF'
+      },
+      tags: ['X7JF']
+    });
+    mockApi()
+      .post(`/adis/orders/${ID}/events`, payload)
+      .reply(201, {});
+
+    await cli(`adi-orders ${ID} events create ${payload}`);
   });
 });

--- a/tests/main.js
+++ b/tests/main.js
@@ -39,6 +39,7 @@ describe('CLI', () => {
   require('./commands/account');
   require('./commands/action');
   require('./commands/action-type');
+  require('./commands/adi-order');
   require('./commands/app-user');
   require('./commands/batch');
   require('./commands/collection');


### PR DESCRIPTION
`evrythng adi-orders create $payload`
`evrythng adi-orders $id read`
`evrythng adi-orders $id events create $payload`

Also adds the `with-errors` switch.