### PR TITLE
Allow any length for  pattern pieces

### DIFF
--- a/src/modules/commands.js
+++ b/src/modules/commands.js
@@ -41,10 +41,17 @@ const showSyntax = (command) => {
   throw new Error(`Available operations for '${firstArg}':\n${specs.join('\n')}`);
 };
 
+/**
+ * Take an arg and pattern spec piece and validate they match.
+ *
+ * @param {string} arg - The argument value, such as 'Ur2Ta6GEFfVAfbCdFd7KnpTd'
+ * @param {string} spec - The pattern spec piece, such as '$id'
+ * @returns {boolean} true if the arg should validate.
+ */
 const matchArg = (arg = '', spec) => {
   const map = {
-    // Value must be an EVRYTHNG ID
-    $id: val => val.length === 24,
+    // Value can be an EVRYTHNG ID, an identifier string, or some customer ID format
+    $id: val => val.length > 0,
     // Value must be JSON
     $payload: (val) => {
       // Some switches work instead of a payload

--- a/tests/modules/commands.js
+++ b/tests/modules/commands.js
@@ -50,7 +50,7 @@ describe('commands', () => {
   it('should throw to identify a partial match', () => {
     const args = ['thngs'];
     const match = () => commands.identify(args);
-    
+
     expect(match).to.throw();
   });
 


### PR DESCRIPTION
Relaxing the '`$id` length must be 24' rule. 

Allows requests like `evrythng thngs gs1:21:3478678 read`, for example.