### PR TITLE
Update docs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,8 @@ add/extend custom functionality as the user requires. These plugins are provided
 with an `api` parameter that contains methods and data they can use to implement
 additional functionality, such as adding new commands.
 
-See the
-[_Plugins_](https://developers.evrythng.com/v3.0/docs/evrythng-cli-plugins#section-published-examples)
-page of the documentation for some example plugin implementations.
+Some example plugins can be
+[found on GitHub](https://github.com/search?q=evrythng-cli-plugin).
 
 
 ### Plugin Requirements

--- a/src/functions/printHelp.js
+++ b/src/functions/printHelp.js
@@ -68,7 +68,7 @@ module.exports = () => {
   logger.info(indent('$ evrythng <command> <params>... [<payload>] [<switches>...]', 4));
 
   logger.info('\nDocumentation:\n');
-  logger.info(indent('https://developers.evrythng.com/docs/evrythng-cli', 4));
+  logger.info(indent('https://github.com/evrythng/evrythng-cli', 4));
 
   logger.info('\nAvailable Commands:\n');
   logger.info(indent('Specify a command name below to see syntax for all its operations.\n', 4));


### PR DESCRIPTION
Point to GitHub instead as a single source of truth.