### PR TITLE
Add commands for shipment notices and containers

### DIFF
--- a/src/commands/shipment-notice.js
+++ b/src/commands/shipment-notice.js
@@ -1,0 +1,30 @@
+/**
+ * (c) Copyright Reserved EVRYTHNG Limited 2019.
+ * All rights reserved. Use of this material is subject to license.
+ */
+
+const http = require('../modules/http');
+
+module.exports = {
+  about: 'Work with shipment notices.',
+  firstArg: 'shipment-notices',
+  operations: {
+    createShipmentNotice: {
+      execute: async ([, json]) => http.post('/shipmentNotices', JSON.parse(json)),
+      pattern: 'create $payload',
+    },
+    readShipmentNotice: {
+      execute: async ([id]) => http.get(`/shipmentNotices/${id}`),
+      pattern: '$id read',
+    },
+    updateShipmentNotice: {
+      execute: async ([id, , json]) =>
+        http.put(`/shipmentNotices/${id}`, JSON.parse(json)),
+      pattern: '$id update $payload',
+    },
+    deleteShipmentNotice: {
+      execute: async ([id]) => http.delete(`/shipmentNotices/${id}`),
+      pattern: '$id delete',
+    },
+  },
+};

--- a/src/commands/shipment-notice.js
+++ b/src/commands/shipment-notice.js
@@ -26,5 +26,23 @@ module.exports = {
       execute: async ([id]) => http.delete(`/shipmentNotices/${id}`),
       pattern: '$id delete',
     },
+
+    createShipmentNoticeContainer: {
+      execute: async ([, , json]) => http.post('/shipmentNotices/containers', JSON.parse(json)),
+      pattern: 'containers create $payload',
+    },
+    readShipmentNoticeContainer: {
+      execute: async ([, id]) => http.get(`/shipmentNotices/containers/${id}`),
+      pattern: 'containers $id read',
+    },
+    updateShipmentNoticeContainer: {
+      execute: async ([, id, , json]) =>
+        http.put(`/shipmentNotices/containers/${id}`, JSON.parse(json)),
+      pattern: 'containers $id update $payload',
+    },
+    deleteShipmentNoticeContainer: {
+      execute: async ([, id]) => http.delete(`/shipmentNotices/containers/${id}`),
+      pattern: 'containers $id delete',
+    },
   },
 };

--- a/src/modules/commands.js
+++ b/src/modules/commands.js
@@ -27,6 +27,7 @@ const COMMAND_LIST = [
   require('../commands/redirector'),
   require('../commands/region'),
   require('../commands/role'),
+  require('../commands/shipment-notice'),
   require('../commands/thng'),
   require('../commands/url'),
 ];

--- a/tests/commands/shipment-notice.js
+++ b/tests/commands/shipment-notice.js
@@ -1,0 +1,67 @@
+/**
+ * (c) Copyright Reserved EVRYTHNG Limited 2019.
+ * All rights reserved. Use of this material is subject to license.
+ */
+
+const { ID, mockApi } = require('../util');
+const cli = require('../../src/functions/cli');
+
+const payload = JSON.stringify({
+  asnId: '9827429837429823828273',
+  version: '1',
+  issueDate: '2019-06-19T16:39:57-08:00',
+  transportation: 'Expedited Freight',
+  parties: [
+    {
+      id: 'gs1:414:01251',
+      type: 'ship-from'
+    },
+    {
+      name: 'The Landmark, Shop No. G14',
+      type: 'ship-to',
+      address: {
+        street: '113-114, Central',
+        city: 'Hong Kong'
+      }
+    }
+  ],
+  tags: [
+    'ongoing',
+    'important',
+    'access-all'
+  ]
+});
+
+describe('shipment-notices', async () => {
+  it('should make correct request for \'shipment-notices create $payload\'', async () => {
+    mockApi()
+      .post('/shipmentNotices', payload)
+      .reply(201, payload);
+
+    await cli(`shipment-notices create ${payload}`);
+  });
+
+  it('should make correct request for \'shipment-notices $id read\'', async () => {
+    mockApi()
+      .get('/shipmentNotices/Ur2KGCnqbfsphqaabbcbsqnq')
+      .reply(200, {});
+
+    await cli(`shipment-notices Ur2KGCnqbfsphqaabbcbsqnq read`);
+  });
+
+  it('should make correct request for \'shipment-notices $id update $payload\'', async () => {
+    mockApi()
+      .put('/shipmentNotices/Ur2KGCnqbfsphqaabbcbsqnq', payload)
+      .reply(200, payload);
+
+    await cli(`shipment-notices Ur2KGCnqbfsphqaabbcbsqnq update ${payload}`);
+  });
+
+  it('should make correct request for \'shipment-notices $id delete\'', async () => {
+    mockApi()
+      .delete('/shipmentNotices/Ur2KGCnqbfsphqaabbcbsqnq')
+      .reply(204);
+
+    await cli(`shipment-notices Ur2KGCnqbfsphqaabbcbsqnq delete`);
+  });
+});

--- a/tests/commands/shipment-notice.js
+++ b/tests/commands/shipment-notice.js
@@ -6,7 +6,7 @@
 const { ID, mockApi } = require('../util');
 const cli = require('../../src/functions/cli');
 
-const payload = JSON.stringify({
+const shipmentNoticePayload = JSON.stringify({
   asnId: '9827429837429823828273',
   version: '1',
   issueDate: '2019-06-19T16:39:57-08:00',
@@ -32,13 +32,30 @@ const payload = JSON.stringify({
   ]
 });
 
+const containerPayload = JSON.stringify({
+  containerId: 'gs1:21:238467',
+  transportationType: 'Pallet',
+  products: [
+    {
+      id: 'gs1:01:000000001234',
+      quantity: 562,
+      unitOfMeasure: 'piece'
+    }
+  ],
+  tags: [
+    'ongoing',
+    'important',
+    'access-all'
+  ]
+});
+
 describe('shipment-notices', async () => {
   it('should make correct request for \'shipment-notices create $payload\'', async () => {
     mockApi()
-      .post('/shipmentNotices', payload)
-      .reply(201, payload);
+      .post('/shipmentNotices', shipmentNoticePayload)
+      .reply(201, shipmentNoticePayload);
 
-    await cli(`shipment-notices create ${payload}`);
+    await cli(`shipment-notices create ${shipmentNoticePayload}`);
   });
 
   it('should make correct request for \'shipment-notices $id read\'', async () => {
@@ -51,10 +68,10 @@ describe('shipment-notices', async () => {
 
   it('should make correct request for \'shipment-notices $id update $payload\'', async () => {
     mockApi()
-      .put('/shipmentNotices/Ur2KGCnqbfsphqaabbcbsqnq', payload)
-      .reply(200, payload);
+      .put('/shipmentNotices/Ur2KGCnqbfsphqaabbcbsqnq', shipmentNoticePayload)
+      .reply(200, shipmentNoticePayload);
 
-    await cli(`shipment-notices Ur2KGCnqbfsphqaabbcbsqnq update ${payload}`);
+    await cli(`shipment-notices Ur2KGCnqbfsphqaabbcbsqnq update ${shipmentNoticePayload}`);
   });
 
   it('should make correct request for \'shipment-notices $id delete\'', async () => {
@@ -63,5 +80,41 @@ describe('shipment-notices', async () => {
       .reply(204);
 
     await cli(`shipment-notices Ur2KGCnqbfsphqaabbcbsqnq delete`);
+  });
+});
+
+describe('shipment-notices containers', async () => {
+  it('should make correct request for \'shipment-notices containers create $payload\'',
+    async () => {
+      mockApi()
+        .post('/shipmentNotices/containers', containerPayload)
+        .reply(201, containerPayload);
+
+      await cli(`shipment-notices containers create ${containerPayload}`);
+    });
+
+  it('should make correct request for \'shipment-notices containers $id read\'', async () => {
+    mockApi()
+      .get('/shipmentNotices/containers/Ur2KGCnqbfsphqaabbcbsqnq')
+      .reply(200, {});
+
+    await cli(`shipment-notices containers Ur2KGCnqbfsphqaabbcbsqnq read`);
+  });
+
+  it('should make correct request for \'shipment-notices containers $id update $payload\'',
+    async () => {
+      mockApi()
+        .put('/shipmentNotices/containers/Ur2KGCnqbfsphqaabbcbsqnq', containerPayload)
+        .reply(200, containerPayload);
+
+      await cli(`shipment-notices containers Ur2KGCnqbfsphqaabbcbsqnq update ${containerPayload}`);
+    });
+
+  it('should make correct request for \'shipment-notices containers $id delete\'', async () => {
+    mockApi()
+      .delete('/shipmentNotices/containers/Ur2KGCnqbfsphqaabbcbsqnq')
+      .reply(204);
+
+    await cli(`shipment-notices containers Ur2KGCnqbfsphqaabbcbsqnq delete`);
   });
 });

--- a/tests/main.js
+++ b/tests/main.js
@@ -54,6 +54,7 @@ describe('CLI', () => {
   require('./commands/redirector');
   require('./commands/region');
   require('./commands/role');
+  require('./commands/shipment-notice');
   require('./commands/thng');
   require('./commands/url');
 


### PR DESCRIPTION
_Shipment Notices_
* `evrythng shipment-notices create $payload`
* `evrythng shipment-notices $id read`
* `evrythng shipment-notices $id update $payload`
* `evrythng shipment-notices $id delete`

_Shipment Notice Containers_
* `evrythng shipment-notices containers create $payload`
* `evrythng shipment-notices containers $id read`
* `evrythng shipment-notices containers $id update $payload`
* `evrythng shipment-notices containers $id delete`