### PR TITLE
Enhance Reactor script upload options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng-cli",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng-cli",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Extensible command line interface for the EVRYTHNG API.",
   "main": "./src/main.js",
   "scripts": {

--- a/src/commands/operator.js
+++ b/src/commands/operator.js
@@ -129,6 +129,22 @@ const removeOperator = (args) => {
   }
 };
 
+/**
+ * Get the current region URL
+ *
+ * @returns {string} The current region URL.
+ */
+const getRegionUrl = () => {
+  const name = config.get('using');
+  if (!name) {
+    logger.error(`Invalid operator: ${name}`);
+    return;
+  }
+
+  const { region } = config.get('operators')[name];
+  return REGIONS[region];
+};
+
 const applyRegion = () => {
   const name = config.get('using');
   if (!name) {
@@ -222,6 +238,7 @@ module.exports = {
     },
   },
   getKey,
+  getRegionUrl,
   applyRegion,
   checkFirstRun,
   resolveKey,

--- a/src/commands/project.js
+++ b/src/commands/project.js
@@ -208,7 +208,7 @@ module.exports = {
         return uploadReactorFiles(projectId, applicationId, scriptPath, manifestPath);
       },
       pattern: '$id applications $id reactor script upload $scriptPath $manifestPath',
-      helpPattern: '$id applications $id reactor script upload $scriptPathOrUrl [$manifestPath]',
+      helpPattern: '$id applications $id reactor script upload $scriptBundleOrUrlPath [$manifestPath]',
     },
     readReactorScriptStatus: {
       execute: async ([projectId, , applicationId]) => {


### PR DESCRIPTION
* Upload using a repository URL (no changes required):
    `$ evrythng projects :id applications :id reactor script upload :repoUrl`
* Upload a local `.zip` bundle (local changes such as config values required):
    `$ evrythng projects :id applications :id reactor script upload :bundlePath`

The existing script file + manifest file upload method remains unchanged:
    `$ evrythng projects :id applications :id reactor script upload :scriptPath :manifestPath`

- [x] Bump version before merge.